### PR TITLE
Adding the HELO command + UT

### DIFF
--- a/core/src/main/java/com/yahoo/smtpnio/async/request/HelloCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/HelloCommand.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+import java.nio.charset.StandardCharsets;
+
+import javax.annotation.Nonnull;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+/**
+ * This class defines a Hello (HELO) command used to greet the server.
+ */
+public class HelloCommand extends AbstractSmtpCommand {
+
+    /** String literal for "HELO". */
+    private static final String HELO = "HELO";
+
+    /** the identify of the client. */
+    private String name;
+
+    /**
+     * Initializes a HELO command object.
+     *
+     * @param name the domain/name that the client greets the server with, a required argument for HELO
+     */
+    public HelloCommand(@Nonnull final String name) {
+        super(HELO);
+        this.name = name;
+    }
+
+    @Nonnull
+    @Override
+    public ByteBuf getCommandLineBytes() {
+        return Unpooled.buffer(command.length() + SmtpClientConstants.CHAR_LEN + name.length() + CRLF_B.length)
+                .writeBytes(command.getBytes(StandardCharsets.US_ASCII))
+                .writeByte(SmtpClientConstants.SPACE)
+                .writeBytes(name.getBytes(StandardCharsets.US_ASCII))
+                .writeBytes(CRLF_B);
+    }
+
+    @Override
+    public SmtpCommandType getCommandType() {
+        return SmtpCommandType.HELO;
+    }
+
+    @Override
+    public void cleanup() {
+        super.cleanup();
+        name = null;
+    }
+}

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/SmtpCommandType.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/SmtpCommandType.java
@@ -12,6 +12,9 @@ public enum SmtpCommandType {
     /** The Extended Hello command (EHLO). */
     EHLO,
 
+    /** The Hello command (HELO). */
+    HELO,
+
     /** The Quit command (QUIT). */
     QUIT
 }

--- a/core/src/test/java/com/yahoo/smtpnio/async/request/HelloCommandTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/request/HelloCommandTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.yahoo.smtpnio.async.exception.SmtpAsyncClientException;
+import com.yahoo.smtpnio.async.response.SmtpResponse;
+
+/**
+ * Unit test for {@link HelloCommand}.
+ */
+public class HelloCommandTest {
+
+    /** Fields to check for cleanup. */
+    private final Set<Field> fieldsToCheck = new HashSet<>();
+
+    /**
+     * Setup reflection.
+     */
+    @BeforeClass
+    public void setUp() {
+        final Class<?> classUnderTest = HelloCommand.class;
+        for (Class<?> c = classUnderTest; c != null; c = c.getSuperclass()) {
+            for (final Field declaredField : c.getDeclaredFields()) {
+                if (!declaredField.getType().isPrimitive() && !Modifier.isStatic(declaredField.getModifiers())) {
+                    declaredField.setAccessible(true);
+                    fieldsToCheck.add(declaredField);
+                }
+            }
+        }
+    }
+
+    /**
+     * Tests the correctness of the commandline content.
+     *
+     * @throws SmtpAsyncClientException will not throw in a successful test
+     * @throws IllegalAccessException will not throw in a successful test
+     */
+    @Test
+    public void testGetCommandLine() throws SmtpAsyncClientException, IllegalAccessException {
+        final SmtpRequest cmd = new HelloCommand("bob");
+        Assert.assertFalse(cmd.isCommandLineDataSensitive());
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII), "HELO bob\r\n",
+                "Expected results mismatched");
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests the {@code getCommandType} method.
+     */
+    @Test
+    public void testGetCommandType() {
+        Assert.assertSame(new HelloCommand("John").getCommandType(), SmtpCommandType.HELO);
+    }
+
+    /**
+     * Test the behavior of the {@code getNextCommandLineAfterContinuation} method, as well as the correctness of the corresponding exception thrown.
+     */
+    @Test
+    public void testGetNextCommandLineAfterContinuation() {
+        SmtpRequest cmd = new HelloCommand("John");
+        try {
+            cmd.getNextCommandLineAfterContinuation(new SmtpResponse("500 resp"));
+            Assert.fail("Exception should've been thrown");
+        } catch (SmtpAsyncClientException ex) {
+            Assert.assertEquals(ex.getFailureType(), SmtpAsyncClientException.FailureType.OPERATION_NOT_SUPPORTED_FOR_COMMAND);
+        }
+    }
+}


### PR DESCRIPTION
## Adding the HELO command

## Description
Adding the HELO command to support interactions with servers that do not support the more advanced, EHLO command

## Motivation and Context
The HELO command is one of the required commands that must be implemented ([RFC 5321 section 4.5.1](https://tools.ietf.org/html/rfc5321#page-61))

## How Has This Been Tested?
- Unit tests with 100% coverage (Very similar to the EHLO command)
- Integration test (Executing the command on a real server and checking the response)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Major release (change is NOT backward compatible with prior release)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
