### PR TITLE
Adding AUTH support with PLAIN, LOGIN and XOAUTH2 mechanisms

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,12 @@ Some of the more distinguishing features of this library are:
 - Leverages the well-established framework [Netty](https://netty.io/)
 - Future-based design enables a clean separation of the SMTP client threads pool and the consumers threads pool
 - Simple Mail Transfer Protocol (SMTP) support [RFC 5321](https://tools.ietf.org/html/rfc5321)
+- **HELO** command support [RFC 821 (Section 3.5)](https://tools.ietf.org/html/rfc821#section-3.5)
 - **EHLO** command support [RFC 1869 (Section 4)](https://tools.ietf.org/html/rfc1869#section-4)
+- **AUTH** command support [RFC 4954](https://tools.ietf.org/html/rfc4954)
+  - *PLAIN* [RFC 4616](https://tools.ietf.org/html/rfc4616)
+  - *LOGIN* [RFC Draft](https://www.ietf.org/archive/id/draft-murchison-sasl-login-00.txt)
+  - *XOAUTH2* [RFC 7628](https://tools.ietf.org/html/rfc7628)
 - **QUIT** command support [RFC 5321 (Section 4.1.1.10)](https://tools.ietf.org/html/rfc5321#section-4.1.1.10)
 
 
@@ -38,7 +43,7 @@ This library is built and managed using [maven](https://maven.apache.org/what-is
 <dependency>
   <groupId>com.yahoo.smtpnio</groupId>
   <artifactId>smtpnio.core</artifactId>
-  <version>1.0.2</version>
+  <version>1.0.3</version>
 </dependency>
 ```
 
@@ -143,7 +148,7 @@ smtpClient.shutdown();
 This release, version 1.0.3, supports the following SMTP commands:
 - **EHLO**
 - **HELO**
-- **AUTH** (PLAIN, LOGIN)
+- **AUTH** (PLAIN, LOGIN, XOAUTH2)
 - **QUIT**
 
 ## Contribute

--- a/README.md
+++ b/README.md
@@ -140,8 +140,10 @@ smtpClient.shutdown();
 
 ## Release
 
-This release, version 1.0.0, is the first official release. The current supported SMTP commands are:
+This release, version 1.0.3, supports the following SMTP commands:
 - **EHLO**
+- **HELO**
+- **AUTH** (PLAIN, LOGIN)
 - **QUIT**
 
 ## Contribute

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.yahoo.smtpnio</groupId>
         <artifactId>smtpnio</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/AbstractAuthenticationCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/AbstractAuthenticationCommand.java
@@ -7,7 +7,6 @@ package com.yahoo.smtpnio.async.request;
 import java.nio.charset.StandardCharsets;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -20,27 +19,8 @@ public abstract class AbstractAuthenticationCommand extends AbstractSmtpCommand 
     /** String literal for "AUTH". */
     private static final String AUTH = "AUTH";
 
-    /** String in place of the actual secret in the debugging data. */
-    private static final String SECRET_PLACEHOLDER = "<secret>";
-
     /** Mechanism used for authentication. */
     private String mechanism;
-
-    /** Authentication secret. */
-    @Nullable
-    private String secret;
-
-    /**
-     * Initializes an AUTH command object used to authenticate via a specified SASL mechanism that can be completed in one command.
-     *
-     * @param mechanism authentication mechanism
-     * @param secret authentication secret
-     */
-    protected AbstractAuthenticationCommand(@Nonnull final String mechanism, @Nonnull final String secret) {
-        super(AUTH);
-        this.mechanism = mechanism;
-        this.secret = secret;
-    }
 
     /**
      * Initializes an AUTH command object used to authenticate via a specified SASL mechanism that cannot be completed in one command
@@ -63,21 +43,16 @@ public abstract class AbstractAuthenticationCommand extends AbstractSmtpCommand 
     @Nonnull
     @Override
     public ByteBuf getCommandLineBytes() {
-        final ByteBuf result = Unpooled.buffer(command.length() + mechanism.length() + CRLF_B.length + SmtpClientConstants.PADDING_LEN)
+        return Unpooled.buffer(command.length() + mechanism.length() + CRLF_B.length + SmtpClientConstants.PADDING_LEN)
                 .writeBytes(command.getBytes(StandardCharsets.US_ASCII))
                 .writeByte(SmtpClientConstants.SPACE)
                 .writeBytes(mechanism.getBytes(StandardCharsets.US_ASCII));
-        if (secret != null) {
-            result.writeByte(SmtpClientConstants.SPACE).writeBytes(secret.getBytes(StandardCharsets.US_ASCII));
-        }
-        return result.writeBytes(CRLF_B);
     }
 
     @Override
     public void cleanup() {
         super.cleanup();
         mechanism = null;
-        secret = null;
     }
 
     @Override
@@ -93,6 +68,6 @@ public abstract class AbstractAuthenticationCommand extends AbstractSmtpCommand 
     @Nonnull
     @Override
     public String getDebugData() {
-        return String.format("%s %s%s%s", AUTH, mechanism, secret == null ? "" : " " + SECRET_PLACEHOLDER, SmtpClientConstants.CRLF);
+        return AUTH + SmtpClientConstants.SPACE + mechanism;
     }
 }

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/AbstractAuthenticationCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/AbstractAuthenticationCommand.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+import java.nio.charset.StandardCharsets;
+
+import javax.annotation.Nonnull;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+/**
+ * This is the base class for all Authentication (AUTH) commands.
+ */
+public abstract class AbstractAuthenticationCommand extends AbstractSmtpCommand {
+
+    /** String literal for "AUTH". */
+    private static final String AUTH = "AUTH";
+
+    /** String in place of the actual secret in the debugging data. */
+    private static final String SECRET = "<secret>";
+
+    /** Mechanism used for authentication. */
+    private String mechanism;
+
+    /** Authentication secret. */
+    private String secret;
+
+    /**
+     * Initializes an AUTH command object used to authenticate via a specified SASL mechanism.
+     *
+     * @param mechanism authentication mechanism
+     * @param secret authentication secret
+     */
+    protected AbstractAuthenticationCommand(@Nonnull final String mechanism, @Nonnull final String secret) {
+        super(AUTH);
+        this.mechanism = mechanism;
+        this.secret = secret;
+    }
+
+    /**
+     * @return mechanism as a string.
+     */
+    public String getMechanism() {
+        return mechanism;
+    }
+
+    @Nonnull
+    @Override
+    public ByteBuf getCommandLineBytes() {
+        return Unpooled.buffer(command.length() + mechanism.length() + CRLF_B.length + SmtpClientConstants.PADDING_LEN)
+                .writeBytes(command.getBytes(StandardCharsets.US_ASCII))
+                .writeByte(SmtpClientConstants.SPACE)
+                .writeBytes(mechanism.getBytes(StandardCharsets.US_ASCII))
+                .writeByte(SmtpClientConstants.SPACE)
+                .writeBytes(secret.getBytes(StandardCharsets.US_ASCII))
+                .writeBytes(CRLF_B);
+    }
+
+    @Override
+    public void cleanup() {
+        super.cleanup();
+        mechanism = null;
+        secret = null;
+    }
+
+    @Override
+    public SmtpCommandType getCommandType() {
+        return SmtpCommandType.AUTH;
+    }
+
+    @Override
+    public boolean isCommandLineDataSensitive() {
+        return true;
+    }
+
+    @Nonnull
+    @Override
+    public String getDebugData() {
+        return String.format("%s %s %s%s", AUTH, mechanism, SECRET, SmtpClientConstants.CRLF);
+    }
+}

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/AbstractAuthenticationCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/AbstractAuthenticationCommand.java
@@ -8,19 +8,19 @@ import java.nio.charset.StandardCharsets;
 
 import javax.annotation.Nonnull;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-
 /**
  * This is the base class for all Authentication (AUTH) commands.
  */
 public abstract class AbstractAuthenticationCommand extends AbstractSmtpCommand {
 
     /** String literal for "AUTH". */
-    private static final String AUTH = "AUTH";
+    protected static final String AUTH = "AUTH";
+
+    /** Byte array for "AUTH". */
+    protected static final byte[] AUTH_B = AUTH.getBytes(StandardCharsets.US_ASCII);
 
     /** Mechanism used for authentication. */
-    private String mechanism;
+    protected String mechanism;
 
     /**
      * Initializes an AUTH command object used to authenticate via a specified SASL mechanism that cannot be completed in one command
@@ -40,15 +40,6 @@ public abstract class AbstractAuthenticationCommand extends AbstractSmtpCommand 
         return mechanism;
     }
 
-    @Nonnull
-    @Override
-    public ByteBuf getCommandLineBytes() {
-        return Unpooled.buffer(command.length() + mechanism.length() + CRLF_B.length + SmtpClientConstants.PADDING_LEN)
-                .writeBytes(command.getBytes(StandardCharsets.US_ASCII))
-                .writeByte(SmtpClientConstants.SPACE)
-                .writeBytes(mechanism.getBytes(StandardCharsets.US_ASCII));
-    }
-
     @Override
     public void cleanup() {
         super.cleanup();
@@ -63,11 +54,5 @@ public abstract class AbstractAuthenticationCommand extends AbstractSmtpCommand 
     @Override
     public boolean isCommandLineDataSensitive() {
         return true;
-    }
-
-    @Nonnull
-    @Override
-    public String getDebugData() {
-        return AUTH + SmtpClientConstants.SPACE + mechanism;
     }
 }

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/AuthenticationLoginCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/AuthenticationLoginCommand.java
@@ -22,10 +22,10 @@ public class AuthenticationLoginCommand extends AbstractAuthenticationCommand {
     private static final String LOGIN = "LOGIN";
 
     /** String in place of the actual username in the debugging data. */
-    private static final String USERNAME_PLACEHOLDER = "<username>";
+    private static final String LOG_USERNAME_PLACEHOLDER = "<username>";
 
     /** String in place of the actual password in the debugging data. */
-    private static final String PASSWORD_PLACEHOLDER = "<password>";
+    private static final String LOG_PASSWORD_PLACEHOLDER = "<password>";
 
     /** Username for the login (base64 encoded string). */
     private String username;
@@ -64,6 +64,13 @@ public class AuthenticationLoginCommand extends AbstractAuthenticationCommand {
         nextInputState = InputState.USERNAME;
     }
 
+    @Nonnull
+    @Override
+    public ByteBuf getCommandLineBytes() {
+        return super.getCommandLineBytes()
+                .writeBytes(CRLF_B);
+    }
+
     @Override
     public ByteBuf getNextCommandLineAfterContinuation(@Nonnull final SmtpResponse serverResponse) {
         final String input;
@@ -94,13 +101,13 @@ public class AuthenticationLoginCommand extends AbstractAuthenticationCommand {
     @Override
     public String getDebugData() {
         if (this.nextInputState == InputState.USERNAME) {
-            return super.getDebugData();
+            return super.getDebugData() + SmtpClientConstants.CRLF;
         }
         if (this.nextInputState == InputState.PASSWORD) {
-            return USERNAME_PLACEHOLDER + SmtpClientConstants.CRLF;
+            return LOG_USERNAME_PLACEHOLDER + SmtpClientConstants.CRLF;
         }
         if (this.nextInputState == InputState.COMPLETED) {
-            return PASSWORD_PLACEHOLDER + SmtpClientConstants.CRLF;
+            return LOG_PASSWORD_PLACEHOLDER + SmtpClientConstants.CRLF;
         }
         return SmtpClientConstants.CRLF;
     }

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/AuthenticationLoginCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/AuthenticationLoginCommand.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+import java.nio.charset.StandardCharsets;
+
+import javax.annotation.Nonnull;
+
+import com.yahoo.smtpnio.async.response.SmtpResponse;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+/**
+ * This class defines the Authentication (AUTH) command using the "LOGIN" mechanism.
+ */
+public class AuthenticationLoginCommand extends AbstractAuthenticationCommand {
+
+    /** String literal for "LOGIN". */
+    private static final String LOGIN = "LOGIN";
+
+    /** String in place of the actual username in the debugging data. */
+    private static final String USERNAME_PLACEHOLDER = "<username>";
+
+    /** String in place of the actual password in the debugging data. */
+    private static final String PASSWORD_PLACEHOLDER = "<password>";
+
+    /** Username for the login (base64 encoded string). */
+    private String username;
+
+    /** Password for the login (base64 encoded string). */
+    private String password;
+
+    /** Variable used to indicate which input to be sent next to the server. */
+    private InputState nextInputState;
+
+    /**
+     * Enum used to keep track of what input to send to the server next.
+     */
+    private enum InputState {
+
+        /** Username should be sent next. */
+        USERNAME,
+
+        /** Password should be sent next. */
+        PASSWORD,
+
+        /** All expected input has been sent and completed. */
+        COMPLETED
+    }
+
+    /**
+     * Initializes an AUTH command to authenticate via the "LOGIN" mechanism.
+     *
+     * @param username username as a base64 encoded string
+     * @param password password as a base64 encoded string
+     */
+    public AuthenticationLoginCommand(@Nonnull final String username, @Nonnull final String password) {
+        super(LOGIN);
+        this.username = username;
+        this.password = password;
+        nextInputState = InputState.USERNAME;
+    }
+
+    @Override
+    public ByteBuf getNextCommandLineAfterContinuation(@Nonnull final SmtpResponse serverResponse) {
+        final String input;
+        if (nextInputState == InputState.USERNAME) {
+            input = username;
+            nextInputState = InputState.PASSWORD;
+        } else if (nextInputState == InputState.PASSWORD) {
+            input = password;
+            nextInputState = InputState.COMPLETED;
+        } else { // COMPLETED state, normal execution should not reach here
+            input = ""; // Fail-safe: In case server asks for more input after username and password, send empty string
+            nextInputState = null;
+        }
+        return Unpooled.buffer(input.length() + CRLF_B.length)
+                .writeBytes(input.getBytes(StandardCharsets.US_ASCII))
+                .writeBytes(CRLF_B);
+    }
+
+    @Override
+    public void cleanup() {
+        super.cleanup();
+        username = null;
+        password = null;
+        nextInputState = null;
+    }
+
+    @Nonnull
+    @Override
+    public String getDebugData() {
+        if (this.nextInputState == InputState.USERNAME) {
+            return super.getDebugData();
+        }
+        if (this.nextInputState == InputState.PASSWORD) {
+            return USERNAME_PLACEHOLDER + SmtpClientConstants.CRLF;
+        }
+        if (this.nextInputState == InputState.COMPLETED) {
+            return PASSWORD_PLACEHOLDER + SmtpClientConstants.CRLF;
+        }
+        return SmtpClientConstants.CRLF;
+    }
+}

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/AuthenticationLoginCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/AuthenticationLoginCommand.java
@@ -67,7 +67,10 @@ public class AuthenticationLoginCommand extends AbstractAuthenticationCommand {
     @Nonnull
     @Override
     public ByteBuf getCommandLineBytes() {
-        return super.getCommandLineBytes()
+        return Unpooled.buffer(command.length() + mechanism.length() + CRLF_B.length + SmtpClientConstants.PADDING_LEN)
+                .writeBytes(AUTH_B)
+                .writeByte(SmtpClientConstants.SPACE)
+                .writeBytes(mechanism.getBytes(StandardCharsets.US_ASCII))
                 .writeBytes(CRLF_B);
     }
 
@@ -101,7 +104,7 @@ public class AuthenticationLoginCommand extends AbstractAuthenticationCommand {
     @Override
     public String getDebugData() {
         if (this.nextInputState == InputState.USERNAME) {
-            return super.getDebugData() + SmtpClientConstants.CRLF;
+            return AUTH + SmtpClientConstants.SPACE + mechanism + SmtpClientConstants.CRLF;
         }
         if (this.nextInputState == InputState.PASSWORD) {
             return LOG_USERNAME_PLACEHOLDER + SmtpClientConstants.CRLF;

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/AuthenticationPlainCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/AuthenticationPlainCommand.java
@@ -11,6 +11,7 @@ import javax.annotation.Nonnull;
 import org.apache.commons.codec.binary.Base64;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 
 /**
  * This class defines the Authentication (AUTH) command using the "PLAIN" mechanism.
@@ -27,38 +28,38 @@ public class AuthenticationPlainCommand extends AbstractAuthenticationCommand {
     private byte[] secret;
 
     /**
-     * Initializes an AUTH command to authenticate via plaintext.
-     *
-     * @param secret base64 encoded authentication secret as a byte array
-     */
-    private AuthenticationPlainCommand(@Nonnull final byte[] secret) {
-        super(PLAIN);
-        this.secret = secret;
-    }
-
-    /**
      * Initializes an AUTH command to authenticate via plaintext. This constructor will encode the username and password into base64.
      *
      * @param username username of the intended sender, usually an email address, in clear text
      * @param password password associated with the above username, in clear text
      */
     public AuthenticationPlainCommand(@Nonnull final String username, @Nonnull final String password) {
-        this(Base64.encodeBase64((SmtpClientConstants.NULL + username + SmtpClientConstants.NULL + password).getBytes(StandardCharsets.US_ASCII)));
+        super(PLAIN);
+        this.secret = Base64.encodeBase64((SmtpClientConstants.NULL + username + SmtpClientConstants.NULL + password)
+                .getBytes(StandardCharsets.US_ASCII));
     }
 
     /**
-     * Initializes an AUTH command to authenticate via plaintext. This constructor will not encode the input for the client.
+     * Initializes an AUTH command to authenticate via plaintext. This constructor will encode the authzid, username and password into base64.
      *
-     * @param secret authentication secret already encoded as a base64 string
+     * @param authorizationIdentity The authorization identity (aka. authzid)
+     * @param username username/authentication identity of the intended sender, usually an email address, in clear text (aka. authcid)
+     * @param password password associated with the above username, in clear text
      */
-    public AuthenticationPlainCommand(@Nonnull final String secret) {
-        this(secret.getBytes(StandardCharsets.US_ASCII));
+    public AuthenticationPlainCommand(@Nonnull final String authorizationIdentity, @Nonnull final String username, @Nonnull final String password) {
+        super(PLAIN);
+        this.secret = Base64.encodeBase64((authorizationIdentity + SmtpClientConstants.NULL + username + SmtpClientConstants.NULL + password)
+                .getBytes(StandardCharsets.US_ASCII));
     }
 
     @Nonnull
     @Override
     public ByteBuf getCommandLineBytes() {
-        return super.getCommandLineBytes()
+        final int numSpaces = 4;
+        return Unpooled.buffer(command.length() + mechanism.length() + secret.length + numSpaces * SmtpClientConstants.CHAR_LEN)
+                .writeBytes(AUTH_B)
+                .writeByte(SmtpClientConstants.SPACE)
+                .writeBytes(mechanism.getBytes(StandardCharsets.US_ASCII))
                 .writeByte(SmtpClientConstants.SPACE)
                 .writeBytes(secret)
                 .writeBytes(CRLF_B);
@@ -73,6 +74,11 @@ public class AuthenticationPlainCommand extends AbstractAuthenticationCommand {
     @Nonnull
     @Override
     public String getDebugData() {
-        return super.getDebugData() + SmtpClientConstants.SPACE + LOG_SECRET_PLACEHOLDER + SmtpClientConstants.CRLF;
+        return new StringBuilder(AUTH)
+                .append(SmtpClientConstants.SPACE)
+                .append(mechanism)
+                .append(SmtpClientConstants.SPACE)
+                .append(LOG_SECRET_PLACEHOLDER)
+                .append(SmtpClientConstants.CRLF).toString();
     }
 }

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/AuthenticationPlainCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/AuthenticationPlainCommand.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import javax.annotation.Nonnull;
+
+/**
+ * This class defines the Authentication (AUTH) command using the "PLAIN" mechanism.
+ */
+public class AuthenticationPlainCommand extends AbstractAuthenticationCommand {
+
+    /** String literal for "PLAIN". */
+    private static final String PLAIN = "PLAIN";
+
+    /**
+     * Initializes an AUTH command to authenticate via plaintext. This constructor will encode the username and password into base64.
+     *
+     * @param username username of the intended sender, usually an email address, in clear text
+     * @param password password associated with the above username, in clear text
+     */
+    public AuthenticationPlainCommand(@Nonnull final String username, @Nonnull final String password) {
+        super(PLAIN, Base64.getEncoder().encodeToString((SmtpClientConstants.NULL + username + SmtpClientConstants.NULL + password)
+                .getBytes(StandardCharsets.US_ASCII)));
+    }
+
+    /**
+     * Initializes an AUTH command to authenticate via plaintext. This constructor will not encode the input for the client.
+     *
+     * @param secret authentication secret already encoded as a base64 string
+     */
+    public AuthenticationPlainCommand(@Nonnull final String secret) {
+        super(PLAIN, secret);
+    }
+}

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/AuthenticationXoauth2Command.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/AuthenticationXoauth2Command.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+import java.nio.charset.StandardCharsets;
+
+import javax.annotation.Nonnull;
+
+import org.apache.commons.codec.binary.Base64;
+
+import com.yahoo.smtpnio.async.response.SmtpResponse;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+/**
+ * This class defines the Authentication (AUTH) command using the "XOAUTH2" mechanism.
+ */
+public class AuthenticationXoauth2Command extends AbstractAuthenticationCommand {
+
+    /** String literal for "XOAUTH2". **/
+    private static final String XOAUTH2 = "XOAUTH2";
+
+    /** String literal for "use=", part of required syntax for the command. **/
+    private static final String USER_EQUAL = "user=";
+
+    /** String literal for "use=", part of required syntax for the command. **/
+    private static final String AUTH_BEARER = "auth=Bearer ";
+
+    /** String in place of the actual secret in the debugging data. */
+    private static final String LOG_SECRET_PLACEHOLDER = "<secret>";
+
+    /** User to be authenticated. **/
+    private String username;
+
+    /** User's OAuth 2.0 access token. **/
+    private String token;
+
+    /**
+     * Initializes an AUTH command to authenticate via the "XOAUTH2" mechanism (OAuth 2.0).
+     *
+     * @param username username of the account holder
+     * @param accessToken OAuth 2.0 access token for the account
+     */
+    public AuthenticationXoauth2Command(@Nonnull final String username, @Nonnull final String accessToken) {
+        super(XOAUTH2);
+        this.username = username;
+        this.token = accessToken;
+    }
+
+    @Override
+    public void cleanup() {
+        super.cleanup();
+        this.username = null;
+        this.token = null;
+    }
+
+    @Nonnull
+    @Override
+    public ByteBuf getCommandLineBytes() {
+        // XOAUTH2 format: "user={username}^Aauth=Bearer {token}^A^A"
+        final String commandStr = new StringBuilder()
+                .append(USER_EQUAL).append(username).append(SmtpClientConstants.SOH)
+                .append(AUTH_BEARER).append(token).append(SmtpClientConstants.SOH).append(SmtpClientConstants.SOH)
+                .toString();
+        return Unpooled.buffer(AUTH_B.length + XOAUTH2.length() + commandStr.length() + SmtpClientConstants.PADDING_LEN)
+                .writeBytes(AUTH_B).writeByte(SmtpClientConstants.SPACE)
+                .writeBytes(XOAUTH2.getBytes(StandardCharsets.US_ASCII)).writeByte(SmtpClientConstants.SPACE)
+                .writeBytes(Base64.encodeBase64(commandStr.getBytes(StandardCharsets.UTF_8)))
+                .writeBytes(CRLF_B);
+    }
+
+    /**
+     * Upon a failed negotiation, the server returns a base64 encoded response indicating the error. The client will then send CRLF
+     * as dummy data back to the server to finalize the negotiation. (See RFC 7628, section 3 for details)
+     *
+     * @param serverResponse contains base64 encoded server response indicating authentication failure
+     * @return {@link ByteBuf} containing CRLF bytes
+     */
+    @Override
+    public ByteBuf getNextCommandLineAfterContinuation(@Nonnull final SmtpResponse serverResponse) {
+        return Unpooled.buffer(CRLF_B.length).writeBytes(CRLF_B);
+    }
+
+    @Nonnull
+    @Override
+    public String getDebugData() {
+        return new StringBuilder(AUTH)
+                .append(SmtpClientConstants.SPACE)
+                .append(mechanism)
+                .append(SmtpClientConstants.SPACE)
+                .append(LOG_SECRET_PLACEHOLDER)
+                .append(SmtpClientConstants.CRLF).toString();
+    }
+}

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/SmtpClientConstants.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/SmtpClientConstants.java
@@ -22,6 +22,9 @@ final class SmtpClientConstants {
     /** NULL character. */
     static final char NULL = '\0';
 
+    /** Start of Header char (aka. CTRL-A or \001). **/
+    static final char SOH = 0x1;
+
     /** Private constructor to avoid constructing instance of this class. */
     private SmtpClientConstants() {
     }

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/SmtpClientConstants.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/SmtpClientConstants.java
@@ -13,6 +13,15 @@ final class SmtpClientConstants {
     /** Length of a char. */
     static final int CHAR_LEN = "a".length();
 
+    /** A set padding length. */
+    static final int PADDING_LEN = 40;
+
+    /** String for CRLF. */
+    static final String CRLF = "\r\n";
+
+    /** NULL character. */
+    static final char NULL = '\0';
+
     /** Private constructor to avoid constructing instance of this class. */
     private SmtpClientConstants() {
     }

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/SmtpCommandType.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/SmtpCommandType.java
@@ -16,5 +16,27 @@ public enum SmtpCommandType {
     HELO,
 
     /** The Quit command (QUIT). */
-    QUIT
+    QUIT,
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    /** The Authentication command (AUTH). */
+    AUTH,
+
 }

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/SmtpCommandType.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/SmtpCommandType.java
@@ -18,25 +18,6 @@ public enum SmtpCommandType {
     /** The Quit command (QUIT). */
     QUIT,
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     /** The Authentication command (AUTH). */
-    AUTH,
-
+    AUTH
 }

--- a/core/src/test/java/com/yahoo/smtpnio/async/request/AuthenticationLoginCommandTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/request/AuthenticationLoginCommandTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.yahoo.smtpnio.async.exception.SmtpAsyncClientException;
+import com.yahoo.smtpnio.async.response.SmtpResponse;
+
+/**
+ * Unit test for {@link AuthenticationLoginCommand}.
+ */
+public class AuthenticationLoginCommandTest {
+
+    /** Fields to check for cleanup. */
+    private final Set<Field> fieldsToCheck = new HashSet<>();
+
+    /**
+     * Setup reflection.
+     */
+    @BeforeClass
+    public void setUp() {
+        final Class<?> classUnderTest = AuthenticationLoginCommand.class;
+        for (Class<?> c = classUnderTest; c != null; c = c.getSuperclass()) {
+            for (final Field declaredField : c.getDeclaredFields()) {
+                if (!declaredField.getType().isPrimitive() && !Modifier.isStatic(declaredField.getModifiers())) {
+                    declaredField.setAccessible(true);
+                    fieldsToCheck.add(declaredField);
+                }
+            }
+        }
+    }
+
+    /**
+     * Tests the sequence of challenges responses. It should first give the username, then the password.
+     *
+     * @throws SmtpAsyncClientException will not throw in this test
+     * @throws IllegalAccessException will not throw in this test
+     */
+    @Test
+    public void testGetNextCommandLineAfterContinuation() throws SmtpAsyncClientException, IllegalAccessException {
+        final SmtpRequest cmd = new AuthenticationLoginCommand("test_user123@example.com", "PasswordisPassword!");
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII), "AUTH LOGIN\r\n",
+                "Expected results mismatched");
+        Assert.assertTrue(cmd.isCommandLineDataSensitive(), "Incorrect flag for isCommandLineDataSensitive");
+
+        final String username = cmd.getNextCommandLineAfterContinuation(new SmtpResponse("334 Enter username:")).toString(StandardCharsets.US_ASCII);
+        Assert.assertEquals(username, "test_user123@example.com\r\n", "Username is incorrect");
+
+        final String password = cmd.getNextCommandLineAfterContinuation(new SmtpResponse("334 Enter password:")).toString(StandardCharsets.US_ASCII);
+        Assert.assertEquals(password, "PasswordisPassword!\r\n", "Password is incorrect");
+
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Test the behavior of the command when additional, unexpected challenges are requested. The response should simply be empty strings.
+     *
+     * @throws SmtpAsyncClientException will not throw in this test
+     * @throws IllegalAccessException will not throw in this test
+     */
+    @Test
+    public void testGetNextCommandLineAfterContinuationExtraPrompts() throws SmtpAsyncClientException, IllegalAccessException {
+        final SmtpRequest cmd = new AuthenticationLoginCommand("user", "pass");
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII), "AUTH LOGIN\r\n",
+                "Expected results mismatched");
+        Assert.assertTrue(cmd.isCommandLineDataSensitive(), "User credentials should be sensitive!");
+
+        final String username = cmd.getNextCommandLineAfterContinuation(new SmtpResponse("334 Enter username:")).toString(StandardCharsets.US_ASCII);
+        Assert.assertEquals(username, "user\r\n", "Username is incorrect");
+
+        final String password = cmd.getNextCommandLineAfterContinuation(new SmtpResponse("334 Enter password:")).toString(StandardCharsets.US_ASCII);
+        Assert.assertEquals(password, "pass\r\n", "Password is incorrect");
+
+        final String extra = cmd.getNextCommandLineAfterContinuation(new SmtpResponse("334 More info:")).toString(StandardCharsets.US_ASCII);
+        Assert.assertEquals(extra, "\r\n", "command input does not match the expected results");
+
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests the {@code getMechanism} method.
+     */
+    @Test
+    public void testGetMechanism() {
+        Assert.assertEquals(new AuthenticationLoginCommand("user", "pass").getMechanism(), "LOGIN", "Incorrect mechanism");
+    }
+
+    /**
+     * Tests the {@code getCommandType} method.
+     */
+    @Test
+    public void testGetCommandType() {
+        Assert.assertEquals(new AuthenticationLoginCommand("user", "password").getCommandType(), SmtpCommandType.AUTH, "Incorrect command type");
+    }
+
+    /**
+     * Tests the {@code getDebugData} method. Sensitive info should not be produced
+     *
+     * @throws SmtpAsyncClientException will not throw in this test
+     */
+    @Test
+    public void testGetDebugData() throws SmtpAsyncClientException {
+        final AuthenticationLoginCommand cmd = new AuthenticationLoginCommand("my_user", "my_pass");
+
+        // Initially, debug data prints the command sent, which is AUTH LOGIN
+        Assert.assertEquals(cmd.getDebugData(), "AUTH LOGIN\r\n", "Wrong debug data");
+
+        // Username prompt
+        cmd.getNextCommandLineAfterContinuation(new SmtpResponse("334 VXNlcm5hbWU6"));
+        Assert.assertEquals(cmd.getDebugData(), "<username>\r\n", "Wrong debug data");
+
+        // Password prompt
+        cmd.getNextCommandLineAfterContinuation(new SmtpResponse("334 UGFzc3dvcmQ6"));
+        Assert.assertEquals(cmd.getDebugData(), "<password>\r\n", "Wrong debug data");
+
+        // Extra prompts
+        for (int i = 0; i < 4; i++) {
+            cmd.getNextCommandLineAfterContinuation(new SmtpResponse("334 Extra stuff"));
+            Assert.assertEquals(cmd.getDebugData(), "\r\n", "Wrong debug data");
+        }
+    }
+}

--- a/core/src/test/java/com/yahoo/smtpnio/async/request/AuthenticationPlainCommandTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/request/AuthenticationPlainCommandTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.yahoo.smtpnio.async.exception.SmtpAsyncClientException;
+import com.yahoo.smtpnio.async.response.SmtpResponse;
+
+/**
+ * Unit test for {@link AuthenticationPlainCommand}.
+ */
+public class AuthenticationPlainCommandTest {
+
+    /** Fields to check for cleanup. */
+    private final Set<Field> fieldsToCheck = new HashSet<>();
+
+    /**
+     * Setup reflection.
+     */
+    @BeforeClass
+    public void setUp() {
+        final Class<?> classUnderTest = AuthenticationPlainCommand.class;
+        for (Class<?> c = classUnderTest; c != null; c = c.getSuperclass()) {
+            for (final Field declaredField : c.getDeclaredFields()) {
+                if (!declaredField.getType().isPrimitive() && !Modifier.isStatic(declaredField.getModifiers())) {
+                    declaredField.setAccessible(true);
+                    fieldsToCheck.add(declaredField);
+                }
+            }
+        }
+    }
+
+    /**
+     * Tests the constructor taking in the username and password in plaintext.
+     *
+     * @throws SmtpAsyncClientException will not throw in this test
+     * @throws IllegalAccessException will not throw in this test
+     */
+    @Test
+    public void testGetCommandLineConstructorUserPass() throws SmtpAsyncClientException, IllegalAccessException {
+        final SmtpRequest cmd = new AuthenticationPlainCommand("test_user123@example.com", "PasswordisPassword!");
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII),
+                "AUTH PLAIN AHRlc3RfdXNlcjEyM0BleGFtcGxlLmNvbQBQYXNzd29yZGlzUGFzc3dvcmQh\r\n", "Expected results mismatched");
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII),
+                "AUTH" + SmtpClientConstants.SPACE + "PLAIN AHRlc3RfdXNlcjEyM0BleGFtcGxlLmNvbQBQYXNzd29yZGlzUGFzc3dvcmQh"
+                        + SmtpClientConstants.CRLF, "Expected results mismatched");
+        Assert.assertTrue(cmd.isCommandLineDataSensitive());
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests the constructor taking the base64 encoded string.
+     *
+     * @throws SmtpAsyncClientException will not throw in this test
+     * @throws IllegalAccessException will not throw in this test
+     */
+    @Test
+    public void testGetCommandLineConstructorSecret() throws SmtpAsyncClientException, IllegalAccessException {
+        final SmtpRequest cmd = new AuthenticationPlainCommand("ThisShouldAlreadyBeBase64Encoded!");
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII),
+                "AUTH PLAIN ThisShouldAlreadyBeBase64Encoded!\r\n", "Expected results mismatched");
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII),
+                "AUTH" + SmtpClientConstants.SPACE + "PLAIN ThisShouldAlreadyBeBase64Encoded!"
+                        + SmtpClientConstants.CRLF, "Expected results mismatched");
+        Assert.assertTrue(cmd.isCommandLineDataSensitive());
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * This tests two equivalent commands using the two different constructors.
+     *
+     * @throws SmtpAsyncClientException will not throw in this test
+     * @throws IllegalAccessException will not throw in this test
+     */
+    @Test
+    public void testEquivalentResponses() throws SmtpAsyncClientException, IllegalAccessException {
+        final SmtpRequest cmd = new AuthenticationPlainCommand("me.user@test.org", "this is my password?");
+        final SmtpRequest cmd2 = new AuthenticationPlainCommand("AG1lLnVzZXJAdGVzdC5vcmcAdGhpcyBpcyBteSBwYXNzd29yZD8=");
+
+        final String expected = "AUTH PLAIN AG1lLnVzZXJAdGVzdC5vcmcAdGhpcyBpcyBteSBwYXNzd29yZD8=\r\n";
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII), expected , "Expected results mismatched");
+        Assert.assertEquals(cmd2.getCommandLineBytes().toString(StandardCharsets.US_ASCII), expected , "Expected results mismatched");
+
+        Assert.assertTrue(cmd.isCommandLineDataSensitive());
+        Assert.assertTrue(cmd2.isCommandLineDataSensitive());
+
+        cmd.cleanup();
+        cmd2.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+            Assert.assertNull(field.get(cmd2), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests the {@code getMechanism} method.
+     */
+    @Test
+    public void testGetMechanism() {
+        Assert.assertEquals(new AuthenticationPlainCommand("secret").getMechanism(), "PLAIN");
+        Assert.assertEquals(new AuthenticationPlainCommand("user", "pass").getMechanism(), "PLAIN");
+    }
+
+    /**
+     * Test the {@code getCommandType} method.
+     */
+    @Test
+    public void testGetCommandType() {
+        Assert.assertEquals(new AuthenticationPlainCommand("user", "password").getCommandType(), SmtpCommandType.AUTH);
+        Assert.assertEquals(new AuthenticationPlainCommand("secret_passphrase").getCommandType(), SmtpCommandType.AUTH);
+    }
+
+    /**
+     * Test the behavior of the {@code getNextCommandLineAfterContinuation} method, as well as the correctness of the corresponding exception thrown.
+     */
+    @Test
+    public void testGetNextCommandLineAfterContinuationUsernamePassword() {
+        final SmtpRequest cmd = new AuthenticationPlainCommand("user", "pw");
+        try {
+            cmd.getNextCommandLineAfterContinuation(new SmtpResponse("400 resp"));
+            Assert.fail("Exception should've been thrown");
+        } catch (SmtpAsyncClientException ex) {
+            Assert.assertEquals(ex.getFailureType(), SmtpAsyncClientException.FailureType.OPERATION_NOT_SUPPORTED_FOR_COMMAND,
+                    "Failure type mismatch");
+        }
+    }
+
+    /**
+     * Test the behavior of the {@code getNextCommandLineAfterContinuation} method, as well as the correctness of the corresponding exception thrown.
+     */
+    @Test
+    public void testGetNextCommandLineAfterContinuationSecrets() {
+        final SmtpRequest cmd = new AuthenticationPlainCommand("username_password");
+        try {
+            cmd.getNextCommandLineAfterContinuation(new SmtpResponse("400 resp"));
+            Assert.fail("Exception should have been thrown this object");
+        } catch (SmtpAsyncClientException ex) {
+            Assert.assertEquals(ex.getFailureType(), SmtpAsyncClientException.FailureType.OPERATION_NOT_SUPPORTED_FOR_COMMAND,
+                    "Failure type mismatch");
+        }
+    }
+
+    /**
+     * Tests the {@code getDebugData} method.
+     */
+    @Test
+    public void testGetDebugData() {
+        Assert.assertEquals(new AuthenticationPlainCommand("Base64 Password").getDebugData(), "AUTH PLAIN <secret>\r\n");
+        Assert.assertEquals(new AuthenticationPlainCommand("Alice", "Apple").getDebugData(), "AUTH PLAIN <secret>\r\n");
+    }
+}

--- a/core/src/test/java/com/yahoo/smtpnio/async/request/AuthenticationXoauth2CommandTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/request/AuthenticationXoauth2CommandTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.yahoo.smtpnio.async.exception.SmtpAsyncClientException;
+import com.yahoo.smtpnio.async.response.SmtpResponse;
+
+/**
+ * Unit test for {@link AuthenticationXoauth2Command}.
+ */
+public class AuthenticationXoauth2CommandTest {
+
+    /** Fields to check for cleanup. */
+    private final Set<Field> fieldsToCheck = new HashSet<>();
+
+    /**
+     * Setup reflection.
+     */
+    @BeforeClass
+    public void setUp() {
+        final Class<?> classUnderTest = AuthenticationXoauth2Command.class;
+        for (Class<?> c = classUnderTest; c != null; c = c.getSuperclass()) {
+            for (final Field declaredField : c.getDeclaredFields()) {
+                if (!declaredField.getType().isPrimitive() && !Modifier.isStatic(declaredField.getModifiers())) {
+                    declaredField.setAccessible(true);
+                    fieldsToCheck.add(declaredField);
+                }
+            }
+        }
+    }
+
+    /**
+     * Tests the constructor taking in the username and oauth access token.
+     *
+     * @throws SmtpAsyncClientException will not throw in this test
+     * @throws IllegalAccessException will not throw in this test
+     */
+    @Test
+    public void testConstructor() throws SmtpAsyncClientException, IllegalAccessException {
+        final SmtpRequest cmd = new AuthenticationXoauth2Command("my_username", "my_token");
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII),
+                "AUTH XOAUTH2 dXNlcj1teV91c2VybmFtZQFhdXRoPUJlYXJlciBteV90b2tlbgEB\r\n", "Expected results mismatched");
+        Assert.assertTrue(cmd.isCommandLineDataSensitive());
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests the {@code getMechanism} method.
+     */
+    @Test
+    public void testGetMechanism() {
+        Assert.assertEquals(new AuthenticationXoauth2Command("abc", "def").getMechanism(), "XOAUTH2");
+    }
+
+    /**
+     * Test the {@code getCommandType} method.
+     */
+    @Test
+    public void testGetCommandType() {
+        Assert.assertEquals(new AuthenticationXoauth2Command("user", "tok").getCommandType(), SmtpCommandType.AUTH);
+    }
+
+    /**
+     * Test the behavior of the {@code getNextCommandLineAfterContinuation} method. It should send CRLF.
+     *
+     * @throws SmtpAsyncClientException will not throw in this test
+     */
+    @Test
+    public void testGetNextCommandLineAfterContinuationFailedCredentials() throws SmtpAsyncClientException {
+        final SmtpRequest cmd = new AuthenticationXoauth2Command("12345", "token");
+        final String response = cmd.getNextCommandLineAfterContinuation(new SmtpResponse("334 Credentials not accepted"))
+                .toString(StandardCharsets.US_ASCII);
+
+        Assert.assertEquals(response, "\r\n", "Incorrect response sent upon a failed OAuth command");
+    }
+
+    /**
+     * Tests the {@code getDebugData} method.
+     */
+    @Test
+    public void testGetDebugData() {
+        Assert.assertEquals(new AuthenticationXoauth2Command("Alice", "token2").getDebugData(), "AUTH XOAUTH2 <secret>\r\n");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.yahoo.smtpnio</groupId>
     <artifactId>smtpnio</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <name>${project.artifactId}</name>
     <url>https://github.com/yahoo/smtp-client-nio</url>
     <description>Parent POM file for smtpnio project</description>


### PR DESCRIPTION
## Description
Adding the ability to authenticate using the *PLAIN* and *LOGIN* mechanisms.

## Motivation and Context
Authentication is necessary to be able to send emails.
- The *PLAIN* mechanism is one of the most commonly used methods. ([RFC Reference](https://tools.ietf.org/html/rfc4616))
- The *LOGIN* mechanism, although older, is still used by many older clients and servers
- The *XOAUTH2* mechanism is a commonly used OAuth 2.0 to authenticate  ([RFC Reference](https://tools.ietf.org/html/rfc7628))

## How Has This Been Tested?
- Unit tests with dummy data to check for correct encoding, formatting, and logging (100% Coverage)
- Checking debugging data to ensure that sensitive secrets are not logged (placeholder text is used)
- Tests with real accounts (Gmail, Yahoo) to verify that correct credentials work
- Tests with real accounts (Gmail, Yahoo) to verify that incorrect credentials do not work

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Major release (change is NOT backward compatible with prior release)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
