### PR TITLE
Change SmtpCommandType to interface

### DIFF
--- a/core/src/main/java/com/yahoo/smtpnio/async/request/ExtendedHelloCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/ExtendedHelloCommand.java
@@ -44,7 +44,7 @@ public class ExtendedHelloCommand extends AbstractSmtpCommand {
 
     @Override
     public SmtpCommandType getCommandType() {
-        return SmtpCommandType.EHLO;
+        return SmtpRFCSupportedCommandType.EHLO;
     }
 
     @Override

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/HelloCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/HelloCommand.java
@@ -44,7 +44,7 @@ public class HelloCommand extends AbstractSmtpCommand {
 
     @Override
     public SmtpCommandType getCommandType() {
-        return SmtpCommandType.HELO;
+        return SmtpRFCSupportedCommandType.HELO;
     }
 
     @Override

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/QuitCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/QuitCommand.java
@@ -21,6 +21,6 @@ public class QuitCommand extends AbstractSmtpCommand {
 
     @Override
     public SmtpCommandType getCommandType() {
-        return SmtpCommandType.QUIT;
+        return SmtpRFCSupportedCommandType.QUIT;
     }
 }

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/SmtpCommandType.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/SmtpCommandType.java
@@ -4,17 +4,9 @@
  */
 package com.yahoo.smtpnio.async.request;
 
-/***
- * Enum used to identify the type of SMTP command that is sent.
+/**
+ * This interface identifies the type of SMTP command that is sent.
  */
-public enum SmtpCommandType {
+public interface SmtpCommandType {
 
-    /** The Extended Hello command (EHLO). */
-    EHLO,
-
-    /** The Hello command (HELO). */
-    HELO,
-
-    /** The Quit command (QUIT). */
-    QUIT
 }

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/SmtpRFCSupportedCommandType.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/SmtpRFCSupportedCommandType.java
@@ -1,0 +1,16 @@
+package com.yahoo.smtpnio.async.request;
+
+
+/***
+ * Enum used to identify RFC SMTP command.
+ */
+enum SmtpRFCSupportedCommandType implements SmtpCommandType {
+    /** The Extended Hello command (EHLO). */
+    EHLO,
+
+    /** The Hello command (HELO). */
+    HELO,
+
+    /** The Quit command (QUIT). */
+    QUIT
+}

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/SmtpRFCSupportedCommandType.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/SmtpRFCSupportedCommandType.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
 package com.yahoo.smtpnio.async.request;
 
 

--- a/core/src/test/java/com/yahoo/smtpnio/async/request/ExtendedHelloCommandTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/request/ExtendedHelloCommandTest.java
@@ -66,9 +66,10 @@ public class ExtendedHelloCommandTest {
      */
     @Test
     public void testGetCommandType() {
-        Assert.assertSame(new ExtendedHelloCommand("test.client.me").getCommandType(), SmtpCommandType.EHLO,
+        Assert.assertSame(new ExtendedHelloCommand("test.client.me").getCommandType(),
+                SmtpRFCSupportedCommandType.EHLO,
                 "Unexpected command type");
-        Assert.assertEquals(SmtpCommandType.EHLO, SmtpCommandType.valueOf("EHLO"), "Unexpected command value");
+        Assert.assertEquals(SmtpRFCSupportedCommandType.EHLO, SmtpRFCSupportedCommandType.valueOf("EHLO"), "Unexpected command value");
     }
 
     /**

--- a/core/src/test/java/com/yahoo/smtpnio/async/request/ExtendedHelloCommandTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/request/ExtendedHelloCommandTest.java
@@ -66,9 +66,7 @@ public class ExtendedHelloCommandTest {
      */
     @Test
     public void testGetCommandType() {
-        Assert.assertSame(new ExtendedHelloCommand("test.client.me").getCommandType(),
-                SmtpRFCSupportedCommandType.EHLO,
-                "Unexpected command type");
+        Assert.assertSame(new ExtendedHelloCommand("test.client.me").getCommandType(), SmtpRFCSupportedCommandType.EHLO, "Unexpected command type");
         Assert.assertEquals(SmtpRFCSupportedCommandType.EHLO, SmtpRFCSupportedCommandType.valueOf("EHLO"), "Unexpected command value");
     }
 

--- a/core/src/test/java/com/yahoo/smtpnio/async/request/HelloCommandTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/request/HelloCommandTest.java
@@ -65,7 +65,7 @@ public class HelloCommandTest {
      */
     @Test
     public void testGetCommandType() {
-        Assert.assertSame(new HelloCommand("John").getCommandType(), SmtpCommandType.HELO);
+        Assert.assertSame(new HelloCommand("John").getCommandType(), SmtpRFCSupportedCommandType.HELO);
     }
 
     /**

--- a/core/src/test/java/com/yahoo/smtpnio/async/request/QuitCommandTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/request/QuitCommandTest.java
@@ -64,7 +64,7 @@ public class QuitCommandTest {
      */
     @Test
     public void testGetCommandType() {
-        Assert.assertSame(new QuitCommand().getCommandType(), SmtpCommandType.QUIT, "Incorrect command type");
+        Assert.assertSame(new QuitCommand().getCommandType(), SmtpRFCSupportedCommandType.QUIT, "Incorrect command type");
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Change SmtpCommandType to interface
- Add SmtpRFCSupportedCommandType enum to represent existing SmtpCommandType enum

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Jedi needs support custom non-RFC command to talk to Proxy team, so the SmtpCommandType should include both RFC and non-RFC commands.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Use previous unit test of ExtendedHelloCommand, HelloCommand and QuitCommand
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Major release (change is NOT backward compatible with prior release)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
