### PR TITLE
Adding AUTH support with PLAIN, LOGIN and XOAUTH2 mechanisms

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,15 +148,7 @@ smtpClient.shutdown();
 This release, version 1.0.3, supports the following SMTP commands:
 - **EHLO**
 - **HELO**
-<<<<<<< HEAD
-<<<<<<< HEAD
 - **AUTH** (PLAIN, LOGIN, XOAUTH2)
-=======
-- **AUTH** (PLAIN, LOGIN)
->>>>>>> 81a62c3... Revising the AUTH architecture + PR revision
-=======
-- **AUTH** (PLAIN, LOGIN, XOAUTH2)
->>>>>>> 0142318... Adding XOAUTH2 support
 - **QUIT**
 
 ## Contribute

--- a/README.md
+++ b/README.md
@@ -25,7 +25,12 @@ Some of the more distinguishing features of this library are:
 - Leverages the well-established framework [Netty](https://netty.io/)
 - Future-based design enables a clean separation of the SMTP client threads pool and the consumers threads pool
 - Simple Mail Transfer Protocol (SMTP) support [RFC 5321](https://tools.ietf.org/html/rfc5321)
+- **HELO** command support [RFC 821 (Section 3.5)](https://tools.ietf.org/html/rfc821#section-3.5)
 - **EHLO** command support [RFC 1869 (Section 4)](https://tools.ietf.org/html/rfc1869#section-4)
+- **AUTH** command support [RFC 4954](https://tools.ietf.org/html/rfc4954)
+  - *PLAIN* [RFC 4616](https://tools.ietf.org/html/rfc4616)
+  - *LOGIN* [RFC Draft](https://www.ietf.org/archive/id/draft-murchison-sasl-login-00.txt)
+  - *XOAUTH2* [RFC 7628](https://tools.ietf.org/html/rfc7628)
 - **QUIT** command support [RFC 5321 (Section 4.1.1.10)](https://tools.ietf.org/html/rfc5321#section-4.1.1.10)
 
 
@@ -38,7 +43,7 @@ This library is built and managed using [maven](https://maven.apache.org/what-is
 <dependency>
   <groupId>com.yahoo.smtpnio</groupId>
   <artifactId>smtpnio.core</artifactId>
-  <version>1.0.2</version>
+  <version>1.0.3</version>
 </dependency>
 ```
 
@@ -140,8 +145,18 @@ smtpClient.shutdown();
 
 ## Release
 
-This release, version 1.0.0, is the first official release. The current supported SMTP commands are:
+This release, version 1.0.3, supports the following SMTP commands:
 - **EHLO**
+- **HELO**
+<<<<<<< HEAD
+<<<<<<< HEAD
+- **AUTH** (PLAIN, LOGIN, XOAUTH2)
+=======
+- **AUTH** (PLAIN, LOGIN)
+>>>>>>> 81a62c3... Revising the AUTH architecture + PR revision
+=======
+- **AUTH** (PLAIN, LOGIN, XOAUTH2)
+>>>>>>> 0142318... Adding XOAUTH2 support
 - **QUIT**
 
 ## Contribute

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.yahoo.smtpnio</groupId>
         <artifactId>smtpnio</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/core/src/main/java/com/yahoo/smtpnio/async/exception/SmtpAsyncClientException.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/exception/SmtpAsyncClientException.java
@@ -57,7 +57,10 @@ public class SmtpAsyncClientException extends Exception {
         INVALID_INPUT("Input is invalid."),
 
         /** Invalid Server Response. */
-        INVALID_SERVER_RESPONSE("The server response is invalid.");
+        INVALID_SERVER_RESPONSE("The server response is invalid."),
+
+        /** Server asks for more input. An example is the extra prompt after username and password in AUTH LOGIN */
+        MORE_INPUT_THAN_EXPECTED("The server ask for more input than expected");
 
         /**
          * Constructor to add an error message for failure type belonging to this enum.

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/AbstractAuthenticationCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/AbstractAuthenticationCommand.java
@@ -16,7 +16,6 @@ public abstract class AbstractAuthenticationCommand extends AbstractSmtpCommand 
     /** String literal for "AUTH". */
     protected static final String AUTH = "AUTH";
 
-
     /** Byte array for "AUTH". */
     protected static final byte[] AUTH_B = AUTH.getBytes(StandardCharsets.US_ASCII);
 
@@ -43,7 +42,7 @@ public abstract class AbstractAuthenticationCommand extends AbstractSmtpCommand 
      */
     protected AbstractAuthenticationCommand(@Nonnull final Mechanism mechanism) {
         super(AUTH);
-        this.mechanism = mechanism.toString();
+        this.mechanism = mechanism.name();
     }
 
     /**

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/AbstractAuthenticationCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/AbstractAuthenticationCommand.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+import java.nio.charset.StandardCharsets;
+
+import javax.annotation.Nonnull;
+
+/**
+ * This is the base class for all Authentication (AUTH) commands.
+ */
+public abstract class AbstractAuthenticationCommand extends AbstractSmtpCommand {
+
+    /** String literal for "AUTH". */
+    protected static final String AUTH = "AUTH";
+
+
+    /** Byte array for "AUTH". */
+    protected static final byte[] AUTH_B = AUTH.getBytes(StandardCharsets.US_ASCII);
+
+    /** Mechanism used for authentication. */
+    protected String mechanism;
+
+    /** Three AUTH mechanisms. */
+    protected enum Mechanism {
+        /** AUTH LOGIN. */
+        LOGIN,
+
+        /** AUTH PLAIN. */
+        PLAIN,
+
+        /** AUTH XOAUTH2. */
+        XOAUTH2
+    }
+
+    /**
+     * Initializes an AUTH command object used to authenticate via a specified SASL mechanism that cannot be completed in one command
+     * and requires additional challenge responses from the server.
+     *
+     * @param mechanism authentication mechanism
+     */
+    protected AbstractAuthenticationCommand(@Nonnull final Mechanism mechanism) {
+        super(AUTH);
+        this.mechanism = mechanism.toString();
+    }
+
+    /**
+     * @return the mechanism as a string.
+     */
+    public String getMechanism() {
+        return mechanism;
+    }
+
+    @Override
+    public void cleanup() {
+        super.cleanup();
+        mechanism = null;
+    }
+
+    @Override
+    public SmtpCommandType getCommandType() {
+        return SmtpRFCSupportedCommandType.AUTH;
+    }
+
+    @Override
+    public boolean isCommandLineDataSensitive() {
+        return true;
+    }
+}

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/AuthenticationLoginCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/AuthenticationLoginCommand.java
@@ -82,7 +82,7 @@ public class AuthenticationLoginCommand extends AbstractAuthenticationCommand {
                 || serverResponse.getReplyType() == SmtpResponse.ReplyType.NEGATIVE_PERMANENT) {
             throw new SmtpAsyncClientException(
                     SmtpAsyncClientException.FailureType.COMMAND_NOT_ALLOWED,
-                    "server replies an error: " + serverResponse);
+                    new StringBuilder("server replies an error: ").append(serverResponse).toString());
         }
         final String input;
         if (nextInputState == InputState.USERNAME) {
@@ -112,14 +112,11 @@ public class AuthenticationLoginCommand extends AbstractAuthenticationCommand {
     @Override
     public String getDebugData() {
         if (this.nextInputState == InputState.USERNAME) {
-            return AUTH + SmtpClientConstants.SPACE + mechanism + SmtpClientConstants.CRLF;
+            return new StringBuilder(AUTH).append(SmtpClientConstants.SPACE).append(mechanism).append(SmtpClientConstants.CRLF).toString();
         }
         if (this.nextInputState == InputState.PASSWORD) {
-            return LOG_USERNAME_PLACEHOLDER + SmtpClientConstants.CRLF;
+            return new StringBuilder(LOG_USERNAME_PLACEHOLDER).append(SmtpClientConstants.CRLF).toString();
         }
-        if (this.nextInputState == InputState.COMPLETED) {
-            return LOG_PASSWORD_PLACEHOLDER + SmtpClientConstants.CRLF;
-        }
-        return SmtpClientConstants.CRLF;
+        return new StringBuilder(LOG_PASSWORD_PLACEHOLDER).append(SmtpClientConstants.CRLF).toString();
     }
 }

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/AuthenticationLoginCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/AuthenticationLoginCommand.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+import java.nio.charset.StandardCharsets;
+
+import javax.annotation.Nonnull;
+
+import com.yahoo.smtpnio.async.exception.SmtpAsyncClientException;
+import com.yahoo.smtpnio.async.response.SmtpResponse;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+/**
+ * This class defines the Authentication (AUTH) command using the "LOGIN" mechanism.
+ */
+public class AuthenticationLoginCommand extends AbstractAuthenticationCommand {
+
+    /** String in place of the actual username in the debugging data. */
+    private static final String LOG_USERNAME_PLACEHOLDER = "<username>";
+
+    /** String in place of the actual password in the debugging data. */
+    private static final String LOG_PASSWORD_PLACEHOLDER = "<password>";
+
+    /** String literal for "LOGIN". */
+    private static final String LOGIN = "LOGIN";
+
+    /** Username for the login (base64 encoded string). */
+    private String username;
+
+    /** Password for the login (base64 encoded string). */
+    private String password;
+
+    /** Variable used to indicate which input to be sent next to the server. */
+    private InputState nextInputState;
+
+    /**
+     * Enum used to keep track of what input to send to the server next.
+     */
+    private enum InputState {
+
+        /** Username should be sent next. */
+        USERNAME,
+
+        /** Password should be sent next. */
+        PASSWORD,
+
+        /** All expected input has been sent and completed. */
+        COMPLETED
+    }
+
+    /**
+     * Initializes an AUTH command to authenticate via the "LOGIN" mechanism.
+     *
+     * @param username username as a base64 encoded string
+     * @param password password as a base64 encoded string
+     */
+    public AuthenticationLoginCommand(@Nonnull final String username, @Nonnull final String password) {
+        super(Mechanism.LOGIN);
+        this.username = username;
+        this.password = password;
+        nextInputState = InputState.USERNAME;
+    }
+
+    @Nonnull
+    @Override
+    public ByteBuf getCommandLineBytes() {
+        return Unpooled.buffer(command.length() + mechanism.length() + CRLF_B.length + SmtpClientConstants.PADDING_LEN)
+                .writeBytes(AUTH_B)
+                .writeByte(SmtpClientConstants.SPACE)
+                .writeBytes(mechanism.getBytes(StandardCharsets.US_ASCII))
+                .writeBytes(CRLF_B);
+    }
+
+    @Override
+    public ByteBuf getNextCommandLineAfterContinuation(@Nonnull final SmtpResponse serverResponse) throws SmtpAsyncClientException {
+        // check if server replies and error.
+        if (serverResponse.getReplyType() == SmtpResponse.ReplyType.NEGATIVE_TRANSIENT
+                || serverResponse.getReplyType() == SmtpResponse.ReplyType.NEGATIVE_PERMANENT) {
+            throw new SmtpAsyncClientException(
+                    SmtpAsyncClientException.FailureType.COMMAND_NOT_ALLOWED,
+                    "server replies an error: " + serverResponse);
+        }
+        final String input;
+        if (nextInputState == InputState.USERNAME) {
+            input = username;
+            nextInputState = InputState.PASSWORD;
+        } else if (nextInputState == InputState.PASSWORD) {
+            input = password;
+            nextInputState = InputState.COMPLETED;
+        } else { // COMPLETED state, normal execution should not reach here
+            throw new SmtpAsyncClientException(
+                    SmtpAsyncClientException.FailureType.MORE_INPUT_THAN_EXPECTED);
+        }
+        return Unpooled.buffer(input.length() + CRLF_B.length)
+                .writeBytes(input.getBytes(StandardCharsets.US_ASCII))
+                .writeBytes(CRLF_B);
+    }
+
+    @Override
+    public void cleanup() {
+        super.cleanup();
+        username = null;
+        password = null;
+        nextInputState = null;
+    }
+
+    @Nonnull
+    @Override
+    public String getDebugData() {
+        if (this.nextInputState == InputState.USERNAME) {
+            return AUTH + SmtpClientConstants.SPACE + mechanism + SmtpClientConstants.CRLF;
+        }
+        if (this.nextInputState == InputState.PASSWORD) {
+            return LOG_USERNAME_PLACEHOLDER + SmtpClientConstants.CRLF;
+        }
+        if (this.nextInputState == InputState.COMPLETED) {
+            return LOG_PASSWORD_PLACEHOLDER + SmtpClientConstants.CRLF;
+        }
+        return SmtpClientConstants.CRLF;
+    }
+}

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/AuthenticationPlainCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/AuthenticationPlainCommand.java
@@ -7,6 +7,7 @@ package com.yahoo.smtpnio.async.request;
 import java.nio.charset.StandardCharsets;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import org.apache.commons.codec.binary.Base64;
 
@@ -27,23 +28,6 @@ public class AuthenticationPlainCommand extends AbstractAuthenticationCommand {
     /** Number of spaces used. */
     private static final int NUM_SPACE = 4;
 
-
-    /** String in place of the actual secret in the debugging data. */
-    private static final String LOG_SECRET_PLACEHOLDER = "<secret>";
-
-    /** Authentication secret. */
-    private byte[] secret;
-
-    /**
-     * Initializes an AUTH command to authenticate via plaintext.
-     *
-     * @param secret base64 encoded authentication secret as a byte array
-     */
-    private AuthenticationPlainCommand(@Nonnull final byte[] secret) {
-        super(PLAIN);
-        this.secret = secret;
-    }
-
     /**
      * Initializes an AUTH command to authenticate via plaintext. This constructor will encode the authzid, username and password into base64.
      *
@@ -51,11 +35,14 @@ public class AuthenticationPlainCommand extends AbstractAuthenticationCommand {
      * @param username username/authentication identity of the intended sender, usually an email address, in clear text (aka. authcid)
      * @param password password associated with the above username, in clear text
      */
-    public AuthenticationPlainCommand(final String authorizationIdentity, @Nonnull final String username, @Nonnull final String password) {
+    public AuthenticationPlainCommand(@Nullable final String authorizationIdentity, @Nonnull final String username, @Nonnull final String password) {
         super(Mechanism.PLAIN);
-        final String authzid = authorizationIdentity == null ? "" : authorizationIdentity;
-        this.secret = Base64.encodeBase64((authzid + SmtpClientConstants.NULL + username + SmtpClientConstants.NULL + password)
-                .getBytes(StandardCharsets.US_ASCII));
+        final StringBuilder authzidBuilder = new StringBuilder();
+        if (authorizationIdentity != null) {
+            authzidBuilder.append(authorizationIdentity);
+        }
+        this.secret = Base64.encodeBase64(authzidBuilder.append(SmtpClientConstants.NULL).append(username).append(SmtpClientConstants.NULL)
+                .append(password).toString().getBytes(StandardCharsets.US_ASCII));
     }
 
     @Nonnull

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/AuthenticationPlainCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/AuthenticationPlainCommand.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+import java.nio.charset.StandardCharsets;
+
+import javax.annotation.Nonnull;
+
+import org.apache.commons.codec.binary.Base64;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+/**
+ * This class defines the Authentication (AUTH) command using the "PLAIN" mechanism.
+ */
+public class AuthenticationPlainCommand extends AbstractAuthenticationCommand {
+
+    /** String in place of the actual secret in the debugging data. */
+    private static final String LOG_SECRET_PLACEHOLDER = "<secret>";
+
+    /** Authentication secret. */
+    private byte[] secret;
+
+    /** Number of spaces used. */
+    private static final int NUM_SPACE = 4;
+
+
+    /** String in place of the actual secret in the debugging data. */
+    private static final String LOG_SECRET_PLACEHOLDER = "<secret>";
+
+    /** Authentication secret. */
+    private byte[] secret;
+
+    /**
+     * Initializes an AUTH command to authenticate via plaintext.
+     *
+     * @param secret base64 encoded authentication secret as a byte array
+     */
+    private AuthenticationPlainCommand(@Nonnull final byte[] secret) {
+        super(PLAIN);
+        this.secret = secret;
+    }
+
+    /**
+     * Initializes an AUTH command to authenticate via plaintext. This constructor will encode the authzid, username and password into base64.
+     *
+     * @param authorizationIdentity The authorization identity (aka. authzid)
+     * @param username username/authentication identity of the intended sender, usually an email address, in clear text (aka. authcid)
+     * @param password password associated with the above username, in clear text
+     */
+    public AuthenticationPlainCommand(final String authorizationIdentity, @Nonnull final String username, @Nonnull final String password) {
+        super(Mechanism.PLAIN);
+        final String authzid = authorizationIdentity == null ? "" : authorizationIdentity;
+        this.secret = Base64.encodeBase64((authzid + SmtpClientConstants.NULL + username + SmtpClientConstants.NULL + password)
+                .getBytes(StandardCharsets.US_ASCII));
+    }
+
+    @Nonnull
+    @Override
+    public ByteBuf getCommandLineBytes() {
+        return Unpooled.buffer(command.length() + mechanism.length() + secret.length + NUM_SPACE * SmtpClientConstants.CHAR_LEN)
+                .writeBytes(AUTH_B)
+                .writeByte(SmtpClientConstants.SPACE)
+                .writeBytes(mechanism.getBytes(StandardCharsets.US_ASCII))
+                .writeByte(SmtpClientConstants.SPACE)
+                .writeBytes(secret)
+                .writeBytes(CRLF_B);
+    }
+
+    @Override
+    public void cleanup() {
+        super.cleanup();
+        this.secret = null;
+    }
+
+    @Nonnull
+    @Override
+    public String getDebugData() {
+        return new StringBuilder(AUTH)
+                .append(SmtpClientConstants.SPACE)
+                .append(mechanism)
+                .append(SmtpClientConstants.SPACE)
+                .append(LOG_SECRET_PLACEHOLDER)
+                .append(SmtpClientConstants.CRLF).toString();
+    }
+}

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/AuthenticationXoauth2Command.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/AuthenticationXoauth2Command.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+import java.nio.charset.StandardCharsets;
+
+import javax.annotation.Nonnull;
+
+import org.apache.commons.codec.binary.Base64;
+
+import com.yahoo.smtpnio.async.response.SmtpResponse;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+/**
+ * This class defines the Authentication (AUTH) command using the "XOAUTH2" mechanism.
+ */
+public class AuthenticationXoauth2Command extends AbstractAuthenticationCommand {
+
+    /** String literal for "XOAUTH2". **/
+    private static final String XOAUTH2 = "XOAUTH2";
+
+    /** String literal for "use=", part of required syntax for the command. **/
+    private static final String USER_EQUAL = "user=";
+
+    /** String literal for "use=", part of required syntax for the command. **/
+    private static final String AUTH_BEARER = "auth=Bearer ";
+
+    /** String in place of the actual secret in the debugging data. */
+    private static final String LOG_SECRET_PLACEHOLDER = "<secret>";
+
+    /** User to be authenticated. **/
+    private String username;
+
+    /** User's OAuth 2.0 access token. **/
+    private String token;
+
+    /**
+     * Initializes an AUTH command to authenticate via the "XOAUTH2" mechanism (OAuth 2.0).
+     *
+     * @param username username of the account holder
+     * @param accessToken OAuth 2.0 access token for the account
+     */
+    public AuthenticationXoauth2Command(@Nonnull final String username, @Nonnull final String accessToken) {
+        super(Mechanism.XOAUTH2);
+        this.username = username;
+        this.token = accessToken;
+    }
+
+    @Override
+    public void cleanup() {
+        super.cleanup();
+        this.username = null;
+        this.token = null;
+    }
+
+    @Nonnull
+    @Override
+    public ByteBuf getCommandLineBytes() {
+        // XOAUTH2 format: "user={username}^Aauth=Bearer {token}^A^A"
+        final String commandStr = new StringBuilder()
+                .append(USER_EQUAL).append(username).append(SmtpClientConstants.SOH)
+                .append(AUTH_BEARER).append(token).append(SmtpClientConstants.SOH).append(SmtpClientConstants.SOH)
+                .toString();
+        return Unpooled.buffer(AUTH_B.length + XOAUTH2.length() + commandStr.length() + SmtpClientConstants.PADDING_LEN)
+                .writeBytes(AUTH_B).writeByte(SmtpClientConstants.SPACE)
+                .writeBytes(XOAUTH2.getBytes(StandardCharsets.US_ASCII)).writeByte(SmtpClientConstants.SPACE)
+                .writeBytes(Base64.encodeBase64(commandStr.getBytes(StandardCharsets.UTF_8)))
+                .writeBytes(CRLF_B);
+    }
+
+    /**
+     * Upon a failed negotiation, the server returns a base64 encoded response indicating the error. The client will then send CRLF
+     * as dummy data back to the server to finalize the negotiation. (See RFC 7628, section 3 for details)
+     *
+     * @param serverResponse contains base64 encoded server response indicating authentication failure
+     * @return {@link ByteBuf} containing CRLF bytes
+     */
+    @Override
+    public ByteBuf getNextCommandLineAfterContinuation(@Nonnull final SmtpResponse serverResponse) {
+        return Unpooled.buffer(CRLF_B.length).writeBytes(CRLF_B);
+    }
+
+    @Nonnull
+    @Override
+    public String getDebugData() {
+        return new StringBuilder(AUTH)
+                .append(SmtpClientConstants.SPACE)
+                .append(mechanism)
+                .append(SmtpClientConstants.SPACE)
+                .append(LOG_SECRET_PLACEHOLDER)
+                .append(SmtpClientConstants.CRLF).toString();
+    }
+}

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/AuthenticationXoauth2Command.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/AuthenticationXoauth2Command.java
@@ -20,9 +20,6 @@ import io.netty.buffer.Unpooled;
  */
 public class AuthenticationXoauth2Command extends AbstractAuthenticationCommand {
 
-    /** String literal for "XOAUTH2". **/
-    private static final String XOAUTH2 = "XOAUTH2";
-
     /** String literal for "use=", part of required syntax for the command. **/
     private static final String USER_EQUAL = "user=";
 
@@ -65,11 +62,9 @@ public class AuthenticationXoauth2Command extends AbstractAuthenticationCommand 
                 .append(USER_EQUAL).append(username).append(SmtpClientConstants.SOH)
                 .append(AUTH_BEARER).append(token).append(SmtpClientConstants.SOH).append(SmtpClientConstants.SOH)
                 .toString();
-        return Unpooled.buffer(AUTH_B.length + XOAUTH2.length() + commandStr.length() + SmtpClientConstants.PADDING_LEN)
-                .writeBytes(AUTH_B).writeByte(SmtpClientConstants.SPACE)
-                .writeBytes(XOAUTH2.getBytes(StandardCharsets.US_ASCII)).writeByte(SmtpClientConstants.SPACE)
-                .writeBytes(Base64.encodeBase64(commandStr.getBytes(StandardCharsets.UTF_8)))
-                .writeBytes(CRLF_B);
+        return Unpooled.buffer(AUTH_B.length + getMechanism().length() + commandStr.length() + SmtpClientConstants.PADDING_LEN).writeBytes(AUTH_B)
+                .writeByte(SmtpClientConstants.SPACE).writeBytes(getMechanism().getBytes(StandardCharsets.US_ASCII))
+                .writeByte(SmtpClientConstants.SPACE).writeBytes(Base64.encodeBase64(commandStr.getBytes(StandardCharsets.UTF_8))).writeBytes(CRLF_B);
     }
 
     /**

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/SmtpClientConstants.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/SmtpClientConstants.java
@@ -13,6 +13,18 @@ final class SmtpClientConstants {
     /** Length of a char. */
     static final int CHAR_LEN = "a".length();
 
+    /** A set padding length. */
+    static final int PADDING_LEN = 40;
+
+    /** String for CRLF. */
+    static final String CRLF = "\r\n";
+
+    /** NULL character. */
+    static final char NULL = '\0';
+
+    /** Start of Header char (aka. CTRL-A or \001). **/
+    static final char SOH = 0x1;
+
     /** Private constructor to avoid constructing instance of this class. */
     private SmtpClientConstants() {
     }

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/SmtpCommandType.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/SmtpCommandType.java
@@ -9,4 +9,9 @@ package com.yahoo.smtpnio.async.request;
  */
 public interface SmtpCommandType {
 
+    /**
+     * @return the type of the command
+     */
+    String getType();
 }
+

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/SmtpCommandType.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/SmtpCommandType.java
@@ -8,10 +8,8 @@ package com.yahoo.smtpnio.async.request;
  * This interface identifies the type of SMTP command that is sent.
  */
 public interface SmtpCommandType {
-
     /**
      * @return the type of the command
      */
     String getType();
 }
-

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/SmtpRFCSupportedCommandType.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/SmtpRFCSupportedCommandType.java
@@ -16,5 +16,16 @@ enum SmtpRFCSupportedCommandType implements SmtpCommandType {
     HELO,
 
     /** The Quit command (QUIT). */
-    QUIT
+    QUIT,
+
+    /** The Authentication command (AUTH). */
+    AUTH,
+
+    /** The Starttls command (STARTTLS). */
+    STARTTLS;
+
+    @Override
+    public String getType() {
+        return this.name();
+    }
 }

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/SmtpRFCSupportedCommandType.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/SmtpRFCSupportedCommandType.java
@@ -19,13 +19,11 @@ enum SmtpRFCSupportedCommandType implements SmtpCommandType {
     QUIT,
 
     /** The Authentication command (AUTH). */
-    AUTH,
-
-    /** The Starttls command (STARTTLS). */
-    STARTTLS;
+    AUTH;
 
     @Override
     public String getType() {
         return this.name();
     }
 }
+

--- a/core/src/test/java/com/yahoo/smtpnio/async/request/AuthenticationLoginCommandTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/request/AuthenticationLoginCommandTest.java
@@ -96,9 +96,17 @@ public class AuthenticationLoginCommandTest {
                     "Wrong SmtpAsyncClientException type");
         }
 
-        // Exception should be catched if server response is 4xx/5xx
+        // Exception should be catched if server response is 5xx
         try {
             cmd.getNextCommandLineAfterContinuation(new SmtpResponse("504 Unrecognized authentication type"));
+            Assert.fail("Exception not catched if server response is 5xx");
+        } catch (SmtpAsyncClientException e) {
+            Assert.assertEquals(e.getFailureType(), SmtpAsyncClientException.FailureType.COMMAND_NOT_ALLOWED, "Wrong SmtpAsyncClientException type");
+        }
+
+        // Exception should be catched if server response is 4xx
+        try {
+            cmd.getNextCommandLineAfterContinuation(new SmtpResponse("455  Server unable to accommodate parameters\n"));
             Assert.fail("Exception not catched if server response is 5xx");
         } catch (SmtpAsyncClientException e) {
             Assert.assertEquals(e.getFailureType(),
@@ -150,15 +158,12 @@ public class AuthenticationLoginCommandTest {
         Assert.assertEquals(cmd.getDebugData(), "<password>\r\n", "Wrong debug data");
 
         // Extra prompts
-        for (int i = 0; i < 4; i++) {
-            try {
-                cmd.getNextCommandLineAfterContinuation(new SmtpResponse("334 Extra stuff"));
-                Assert.fail("Exception not catched after server ask for more data");
-            } catch (SmtpAsyncClientException e) {
-                Assert.assertEquals(e.getFailureType(),
-                        SmtpAsyncClientException.FailureType.MORE_INPUT_THAN_EXPECTED,
-                        "Wrong SmtpAsyncClientException type");
-            }
+        try {
+            cmd.getNextCommandLineAfterContinuation(new SmtpResponse("334 Extra stuff"));
+            Assert.fail("Exception not catched after server ask for more data");
+        } catch (SmtpAsyncClientException e) {
+            Assert.assertEquals(e.getFailureType(), SmtpAsyncClientException.FailureType.MORE_INPUT_THAN_EXPECTED,
+                    "Wrong SmtpAsyncClientException type");
         }
     }
 }

--- a/core/src/test/java/com/yahoo/smtpnio/async/request/AuthenticationLoginCommandTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/request/AuthenticationLoginCommandTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.yahoo.smtpnio.async.exception.SmtpAsyncClientException;
+import com.yahoo.smtpnio.async.response.SmtpResponse;
+
+/**
+ * Unit test for {@link AuthenticationLoginCommand}.
+ */
+public class AuthenticationLoginCommandTest {
+
+    /** Fields to check for cleanup. */
+    private final Set<Field> fieldsToCheck = new HashSet<>();
+
+    /**
+     * Setup reflection.
+     */
+    @BeforeClass
+    public void setUp() {
+        final Class<?> classUnderTest = AuthenticationLoginCommand.class;
+        for (Class<?> c = classUnderTest; c != null; c = c.getSuperclass()) {
+            for (final Field declaredField : c.getDeclaredFields()) {
+                if (!declaredField.getType().isPrimitive() && !Modifier.isStatic(declaredField.getModifiers())) {
+                    declaredField.setAccessible(true);
+                    fieldsToCheck.add(declaredField);
+                }
+            }
+        }
+    }
+
+    /**
+     * Tests the sequence of challenges responses. It should first give the username, then the password.
+     *
+     * @throws SmtpAsyncClientException will not throw in this test
+     * @throws IllegalAccessException will not throw in this test
+     */
+    @Test
+    public void testGetNextCommandLineAfterContinuation() throws SmtpAsyncClientException, IllegalAccessException {
+        final SmtpRequest cmd = new AuthenticationLoginCommand("test_user123@example.com", "PasswordisPassword!");
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII), "AUTH LOGIN\r\n",
+                "Expected results mismatched");
+        Assert.assertTrue(cmd.isCommandLineDataSensitive(), "Incorrect flag for isCommandLineDataSensitive");
+
+        final String username = cmd.getNextCommandLineAfterContinuation(new SmtpResponse("334 Enter username:")).toString(StandardCharsets.US_ASCII);
+        Assert.assertEquals(username, "test_user123@example.com\r\n", "Username is incorrect");
+
+        final String password = cmd.getNextCommandLineAfterContinuation(new SmtpResponse("334 Enter password:")).toString(StandardCharsets.US_ASCII);
+        Assert.assertEquals(password, "PasswordisPassword!\r\n", "Password is incorrect");
+
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Test the behavior of the command when additional, unexpected challenges are requested. The response should simply be empty strings.
+     *
+     * @throws SmtpAsyncClientException will not throw in this test
+     * @throws IllegalAccessException will not throw in this test
+     */
+    @Test
+    public void testGetNextCommandLineAfterContinuationExtraPrompts() throws SmtpAsyncClientException, IllegalAccessException {
+        final SmtpRequest cmd = new AuthenticationLoginCommand("user", "pass");
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII), "AUTH LOGIN\r\n",
+                "Expected results mismatched");
+        Assert.assertTrue(cmd.isCommandLineDataSensitive(), "User credentials should be sensitive!");
+
+        final String username = cmd.getNextCommandLineAfterContinuation(new SmtpResponse("334 Enter username:")).toString(StandardCharsets.US_ASCII);
+        Assert.assertEquals(username, "user\r\n", "Username is incorrect");
+
+        final String password = cmd.getNextCommandLineAfterContinuation(new SmtpResponse("334 Enter password:")).toString(StandardCharsets.US_ASCII);
+        Assert.assertEquals(password, "pass\r\n", "Password is incorrect");
+
+        // Exception should be catched if server asks for more input
+        try {
+            cmd.getNextCommandLineAfterContinuation(new SmtpResponse("334 Extra stuff"));
+            Assert.fail("Exception not catched after server ask for more data");
+        } catch (SmtpAsyncClientException e) {
+            Assert.assertEquals(e.getFailureType(),
+                    SmtpAsyncClientException.FailureType.MORE_INPUT_THAN_EXPECTED,
+                    "Wrong SmtpAsyncClientException type");
+        }
+
+        // Exception should be catched if server response is 4xx/5xx
+        try {
+            cmd.getNextCommandLineAfterContinuation(new SmtpResponse("504 Unrecognized authentication type"));
+            Assert.fail("Exception not catched if server response is 5xx");
+        } catch (SmtpAsyncClientException e) {
+            Assert.assertEquals(e.getFailureType(),
+                    SmtpAsyncClientException.FailureType.COMMAND_NOT_ALLOWED,
+                    "Wrong SmtpAsyncClientException type");
+        }
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests the {@code getMechanism} method.
+     */
+    @Test
+    public void testGetMechanism() {
+        Assert.assertEquals(new AuthenticationLoginCommand("user", "pass").getMechanism(), "LOGIN", "Incorrect mechanism");
+    }
+
+    /**
+     * Tests the {@code getCommandType} method.
+     */
+    @Test
+    public void testGetCommandType() {
+        Assert.assertEquals(new AuthenticationLoginCommand("user", "password").getCommandType(), SmtpRFCSupportedCommandType.AUTH,
+                "Incorrect command type");
+    }
+
+    /**
+     * Tests the {@code getDebugData} method. Sensitive info should not be produced
+     *
+     * @throws SmtpAsyncClientException will not throw in this test
+     */
+    @Test
+    public void testGetDebugData() throws SmtpAsyncClientException {
+        final AuthenticationLoginCommand cmd = new AuthenticationLoginCommand("my_user", "my_pass");
+
+        // Initially, debug data prints the command sent, which is AUTH LOGIN
+        Assert.assertEquals(cmd.getDebugData(), "AUTH LOGIN\r\n", "Wrong debug data");
+
+        // Username prompt
+        cmd.getNextCommandLineAfterContinuation(new SmtpResponse("334 VXNlcm5hbWU6"));
+        Assert.assertEquals(cmd.getDebugData(), "<username>\r\n", "Wrong debug data");
+
+        // Password prompt
+        cmd.getNextCommandLineAfterContinuation(new SmtpResponse("334 UGFzc3dvcmQ6"));
+        Assert.assertEquals(cmd.getDebugData(), "<password>\r\n", "Wrong debug data");
+
+        // Extra prompts
+        for (int i = 0; i < 4; i++) {
+            try {
+                cmd.getNextCommandLineAfterContinuation(new SmtpResponse("334 Extra stuff"));
+                Assert.fail("Exception not catched after server ask for more data");
+            } catch (SmtpAsyncClientException e) {
+                Assert.assertEquals(e.getFailureType(),
+                        SmtpAsyncClientException.FailureType.MORE_INPUT_THAN_EXPECTED,
+                        "Wrong SmtpAsyncClientException type");
+            }
+        }
+    }
+}

--- a/core/src/test/java/com/yahoo/smtpnio/async/request/AuthenticationPlainCommandTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/request/AuthenticationPlainCommandTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.yahoo.smtpnio.async.exception.SmtpAsyncClientException;
+import com.yahoo.smtpnio.async.response.SmtpResponse;
+
+/**
+ * Unit test for {@link AuthenticationPlainCommand}.
+ */
+public class AuthenticationPlainCommandTest {
+
+    /** Fields to check for cleanup. */
+    private final Set<Field> fieldsToCheck = new HashSet<>();
+
+    /**
+     * Setup reflection.
+     */
+    @BeforeClass
+    public void setUp() {
+        final Class<?> classUnderTest = AuthenticationPlainCommand.class;
+        for (Class<?> c = classUnderTest; c != null; c = c.getSuperclass()) {
+            for (final Field declaredField : c.getDeclaredFields()) {
+                if (!declaredField.getType().isPrimitive() && !Modifier.isStatic(declaredField.getModifiers())) {
+                    declaredField.setAccessible(true);
+                    fieldsToCheck.add(declaredField);
+                }
+            }
+        }
+    }
+
+    /**
+     * Tests the constructor taking in the username and password in plaintext.
+     *
+     * @throws SmtpAsyncClientException will not throw in this test
+     * @throws IllegalAccessException will not throw in this test
+     */
+    @Test
+    public void testConstructorUsernamePassword() throws SmtpAsyncClientException, IllegalAccessException {
+        final SmtpRequest cmd = new AuthenticationPlainCommand(null, "test_user123@example.com", "PasswordisPassword!");
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII),
+                "AUTH PLAIN AHRlc3RfdXNlcjEyM0BleGFtcGxlLmNvbQBQYXNzd29yZGlzUGFzc3dvcmQh\r\n", "Expected results mismatched");
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII),
+                "AUTH" + SmtpClientConstants.SPACE + "PLAIN AHRlc3RfdXNlcjEyM0BleGFtcGxlLmNvbQBQYXNzd29yZGlzUGFzc3dvcmQh"
+                        + SmtpClientConstants.CRLF, "Expected results mismatched");
+        Assert.assertTrue(cmd.isCommandLineDataSensitive());
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests the constructor taking in the authorization id, username and password in plaintext.
+     *
+     * @throws SmtpAsyncClientException will not throw in this test
+     * @throws IllegalAccessException will not throw in this test
+     */
+    @Test
+    public void testConstructorAuthIdUsernamePassword() throws SmtpAsyncClientException, IllegalAccessException {
+        final SmtpRequest cmd = new AuthenticationPlainCommand("myid", "test_user123@example.com", "PasswordisPassword!");
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII),
+                "AUTH PLAIN bXlpZAB0ZXN0X3VzZXIxMjNAZXhhbXBsZS5jb20AUGFzc3dvcmRpc1Bhc3N3b3JkIQ==\r\n", "Expected results mismatched");
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII),
+                "AUTH" + SmtpClientConstants.SPACE + "PLAIN bXlpZAB0ZXN0X3VzZXIxMjNAZXhhbXBsZS5jb20AUGFzc3dvcmRpc1Bhc3N3b3JkIQ=="
+                        + SmtpClientConstants.CRLF, "Expected results mismatched");
+        Assert.assertTrue(cmd.isCommandLineDataSensitive());
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests the {@code getMechanism} method.
+     */
+    @Test
+    public void testGetMechanism() {
+        Assert.assertEquals(new AuthenticationPlainCommand(null, "user", "pass").getMechanism(), "PLAIN");
+    }
+
+    /**
+     * Test the {@code getCommandType} method.
+     */
+    @Test
+    public void testGetCommandType() {
+        Assert.assertEquals(new AuthenticationPlainCommand(null, "user", "password").getCommandType(), SmtpRFCSupportedCommandType.AUTH);
+    }
+
+    /**
+     * Test the behavior of the {@code getNextCommandLineAfterContinuation} method, as well as the correctness of the corresponding exception thrown.
+     */
+    @Test
+    public void testGetNextCommandLineAfterContinuationUsernamePassword() {
+        final SmtpRequest cmd = new AuthenticationPlainCommand(null, "user", "pw");
+        try {
+            cmd.getNextCommandLineAfterContinuation(new SmtpResponse("400 resp"));
+            Assert.fail("Exception should've been thrown");
+        } catch (SmtpAsyncClientException ex) {
+            Assert.assertEquals(ex.getFailureType(), SmtpAsyncClientException.FailureType.OPERATION_NOT_SUPPORTED_FOR_COMMAND,
+                    "Failure type mismatch");
+        }
+    }
+
+    /**
+     * Tests the {@code getDebugData} method.
+     */
+    @Test
+    public void testGetDebugData() {
+        Assert.assertEquals(new AuthenticationPlainCommand(null, "Alice", "Apple").getDebugData(), "AUTH PLAIN <secret>\r\n");
+    }
+}

--- a/core/src/test/java/com/yahoo/smtpnio/async/request/AuthenticationXoauth2CommandTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/request/AuthenticationXoauth2CommandTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.yahoo.smtpnio.async.exception.SmtpAsyncClientException;
+import com.yahoo.smtpnio.async.response.SmtpResponse;
+
+/**
+ * Unit test for {@link AuthenticationXoauth2Command}.
+ */
+public class AuthenticationXoauth2CommandTest {
+
+    /** Fields to check for cleanup. */
+    private final Set<Field> fieldsToCheck = new HashSet<>();
+
+    /**
+     * Setup reflection.
+     */
+    @BeforeClass
+    public void setUp() {
+        final Class<?> classUnderTest = AuthenticationXoauth2Command.class;
+        for (Class<?> c = classUnderTest; c != null; c = c.getSuperclass()) {
+            for (final Field declaredField : c.getDeclaredFields()) {
+                if (!declaredField.getType().isPrimitive() && !Modifier.isStatic(declaredField.getModifiers())) {
+                    declaredField.setAccessible(true);
+                    fieldsToCheck.add(declaredField);
+                }
+            }
+        }
+    }
+
+    /**
+     * Tests the constructor taking in the username and oauth access token.
+     *
+     * @throws SmtpAsyncClientException will not throw in this test
+     * @throws IllegalAccessException will not throw in this test
+     */
+    @Test
+    public void testConstructor() throws SmtpAsyncClientException, IllegalAccessException {
+        final SmtpRequest cmd = new AuthenticationXoauth2Command("my_username", "my_token");
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII),
+                "AUTH XOAUTH2 dXNlcj1teV91c2VybmFtZQFhdXRoPUJlYXJlciBteV90b2tlbgEB\r\n", "Expected results mismatched");
+        Assert.assertTrue(cmd.isCommandLineDataSensitive());
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests the {@code getMechanism} method.
+     */
+    @Test
+    public void testGetMechanism() {
+        Assert.assertEquals(new AuthenticationXoauth2Command("abc", "def").getMechanism(), "XOAUTH2");
+    }
+
+    /**
+     * Test the {@code getCommandType} method.
+     */
+    @Test
+    public void testGetCommandType() {
+        Assert.assertEquals(new AuthenticationXoauth2Command("user", "tok").getCommandType(), SmtpRFCSupportedCommandType.AUTH);
+    }
+
+    /**
+     * Test the behavior of the {@code getNextCommandLineAfterContinuation} method. It should send CRLF.
+     *
+     * @throws SmtpAsyncClientException will not throw in this test
+     */
+    @Test
+    public void testGetNextCommandLineAfterContinuationFailedCredentials() throws SmtpAsyncClientException {
+        final SmtpRequest cmd = new AuthenticationXoauth2Command("12345", "token");
+        final String response = cmd.getNextCommandLineAfterContinuation(new SmtpResponse("334 Credentials not accepted"))
+                .toString(StandardCharsets.US_ASCII);
+
+        Assert.assertEquals(response, "\r\n", "Incorrect response sent upon a failed OAuth command");
+    }
+
+    /**
+     * Tests the {@code getDebugData} method.
+     */
+    @Test
+    public void testGetDebugData() {
+        Assert.assertEquals(new AuthenticationXoauth2Command("Alice", "token2").getDebugData(), "AUTH XOAUTH2 <secret>\r\n");
+    }
+}

--- a/core/src/test/java/com/yahoo/smtpnio/async/request/SmtpCommandTypeTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/request/SmtpCommandTypeTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Test for {@link SmtpCommandType}.
+ *
+ * @author czhang03
+ */
+public class SmtpCommandTypeTest {
+
+    /**
+     * Test type.
+     */
+    @Test
+    public void test() {
+        final SmtpCommandType type = SmtpRFCSupportedCommandType.EHLO;
+        Assert.assertEquals(type.getType(), "EHLO", "type should match");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler</artifactId>
-                <version>4.1.50.Final</version>
+                <version>4.1.48.Final</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.mail</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.yahoo.smtpnio</groupId>
     <artifactId>smtpnio</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <name>${project.artifactId}</name>
     <url>https://github.com/yahoo/smtp-client-nio</url>
     <description>Parent POM file for smtpnio project</description>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler</artifactId>
-                <version>4.1.5.Final</version>
+                <version>4.1.50.Final</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.mail</groupId>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Take over [AUTH PR#6](https://github.com/yahoo/smtp-client-nio/pull/6/commits), which added the ability to authenticate using the PLAIN/LOGIN/XOAUTH2 mechanisms, and address comments.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
From [AUTH PR#6](https://github.com/yahoo/smtp-client-nio/pull/6/commits)
> Authentication is necessary to be able to send emails.
> 
> The PLAIN mechanism is one of the most commonly used methods. [(RFC Reference)](https://tools.ietf.org/html/rfc4616)
> The LOGIN mechanism, although older, is still used by many older clients and servers
> The XOAUTH2 mechanism is a commonly used OAuth 2.0 to authenticate [(RFC Reference)](https://tools.ietf.org/html/rfc7628)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Use existing unit test. Make some change to AuthenticationLoginCommandTest to test if exceptions are caught correctly.
- Test AUTH LOGIN/ PLAIN and OXAUTH2 with real Gmail/Yahoo/Aol accounts. 
- Outlook only support starttls over port 587/25,  so it needs a different connection flow via starttls. Will be solved in another PR. 
- Refer to [smtp-nio test](https://docs.google.com/spreadsheets/d/1XLhJ6giVsU2FIBIN1MPFC88YDW8XsxN6QneMiCKUEgM/edit#gid=0) for more details. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Major release (change is NOT backward compatible with prior release)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
