### PR TITLE
Fix to close connection upon exception during waiting for greetings

### DIFF
--- a/core/src/main/java/com/yahoo/smtpnio/async/client/SmtpAsyncClient.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/client/SmtpAsyncClient.java
@@ -14,6 +14,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongUnaryOperator;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.net.ssl.SNIHostName;
 import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLEngine;
@@ -133,6 +134,7 @@ public class SmtpAsyncClient {
                             future.cause());
                     sessionFuture.done(ex);
                     logger.error(CONNECT_RESULT_REC, "N/A", sessionCtx, "failure", host, port, enableSsl, sniNames, ex);
+                    closeChannel(nettyConnectFuture.channel());
                     return;
                 }
                 // add the session specific handlers
@@ -171,6 +173,17 @@ public class SmtpAsyncClient {
             }
         });
         return sessionFuture;
+    }
+
+    /**
+     * Closes channel.
+     *
+     * @param channel the channel
+     */
+    private void closeChannel(@Nullable final Channel channel) {
+        if (channel != null && channel.isActive()) {
+            channel.close();
+        }
     }
 
     /**

--- a/core/src/test/java/com/yahoo/smtpnio/async/client/SmtpAsyncClientTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/client/SmtpAsyncClientTest.java
@@ -771,7 +771,6 @@ public class SmtpAsyncClientTest {
         Assert.assertEquals(handlerCaptorLast.getAllValues().size(), 0, "Unexpected count of ChannelHandler added.");
 
         // verify logging messages
-        // verify logging messages
         Mockito.verify(logger, Mockito.times(1)).error(
                 Mockito.eq("[{},{}] connect operation complete. result={}, host={}, port={}, sslEnabled={}, sniNames={}"), Mockito.eq("N/A"),
                 Mockito.eq("N/A"), Mockito.eq("failure"), Mockito.eq("smtp.foo.com"), Mockito.eq(993), Mockito.eq(true),
@@ -794,8 +793,6 @@ public class SmtpAsyncClientTest {
         Assert.assertEquals(actual.getCause().getClass(), ConnectTimeoutException.class, "Cause should be connection timeout exception");
         Assert.assertSame(actual.getCause(), nettyConnectFuture.cause(), "Cause should be same object");
         Assert.assertEquals(actual.getFailureType(), FailureType.WRITE_TO_SERVER_FAILED, "Exception type should be CONNECTION_TIMEOUT_EXCEPTION");
-
-
     }
 
     /**

--- a/core/src/test/java/com/yahoo/smtpnio/async/client/SmtpAsyncClientTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/client/SmtpAsyncClientTest.java
@@ -9,7 +9,9 @@ import java.net.SocketAddress;
 import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import javax.net.ssl.SSLException;
@@ -22,6 +24,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.yahoo.smtpnio.async.exception.SmtpAsyncClientException;
+import com.yahoo.smtpnio.async.exception.SmtpAsyncClientException.FailureType;
 import com.yahoo.smtpnio.async.netty.SmtpClientConnectHandler;
 import com.yahoo.smtpnio.client.SmtpClientRespReader;
 import com.yahoo.smtpnio.command.SmtpClientRespDecoder;
@@ -31,6 +34,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ConnectTimeoutException;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.string.StringDecoder;
@@ -447,6 +451,7 @@ public class SmtpAsyncClientTest {
         Mockito.when(nettyChannel.pipeline()).thenReturn(nettyPipeline);
         Mockito.when(nettyConnectFuture.channel()).thenReturn(nettyChannel);
         Mockito.when(bootstrap.connect(Mockito.anyString(), Mockito.anyInt())).thenReturn(nettyConnectFuture);
+        Mockito.when(nettyChannel.isActive()).thenReturn(true);
         Mockito.when(logger.isTraceEnabled()).thenReturn(true);
 
         final SmtpAsyncClient client = new SmtpAsyncClient(bootstrap, group, logger);
@@ -510,6 +515,8 @@ public class SmtpAsyncClientTest {
                         Mockito.eq(null),
                         Mockito.isA(SmtpAsyncClientException.class)
                 );
+        Mockito.verify(nettyChannel, Mockito.times(1)).isActive();
+        Mockito.verify(nettyChannel, Mockito.times(1)).close();
     }
 
     /**
@@ -527,6 +534,7 @@ public class SmtpAsyncClientTest {
         final ChannelPipeline nettyPipeline = Mockito.mock(ChannelPipeline.class);
 
         Mockito.when(nettyConnectFuture.isSuccess()).thenReturn(false);
+        Mockito.when(nettyChannel.isActive()).thenReturn(false);
         Mockito.when(nettyChannel.pipeline()).thenReturn(nettyPipeline);
         Mockito.when(nettyConnectFuture.channel()).thenReturn(nettyChannel);
         Mockito.when(bootstrap.connect(Mockito.anyString(), Mockito.anyInt())).thenReturn(nettyConnectFuture);
@@ -594,6 +602,8 @@ public class SmtpAsyncClientTest {
                         Mockito.eq(null),
                         Mockito.isA(SmtpAsyncClientException.class)
                 );
+        Mockito.verify(nettyChannel, Mockito.times(1)).isActive();
+        Mockito.verify(nettyChannel, Mockito.times(0)).close(); // since channel is not active
     }
 
     /**
@@ -699,6 +709,93 @@ public class SmtpAsyncClientTest {
         // Next ID should be the max value of Long
         Assert.assertEquals(((AtomicLong) Whitebox.getInternalState(client, "sessionCount")).get(),
                 Long.MAX_VALUE, "The session ID did not wrap around properly");
+    }
+
+    /**
+     * Tests createSession method with failure when channel is null.
+     *
+     * @throws SSLException will not throw
+     * @throws URISyntaxException will not throw
+     * @throws Exception when calling operationComplete() at GenericFutureListener
+     */
+    @Test
+    public void testCreateSessionConnectionFailedChannelIsNull() throws SSLException, URISyntaxException, Exception {
+        final Bootstrap bootstrap = Mockito.mock(Bootstrap.class);
+        final ChannelFuture nettyConnectFuture = Mockito.mock(ChannelFuture.class);
+        Mockito.when(nettyConnectFuture.isSuccess()).thenReturn(false);
+
+        final ChannelPipeline nettyPipeline = Mockito.mock(ChannelPipeline.class);
+
+        Mockito.when(nettyConnectFuture.cause()).thenReturn(new ConnectTimeoutException("connection timed out"));
+        Mockito.when(bootstrap.connect(Mockito.anyString(), Mockito.anyInt())).thenReturn(nettyConnectFuture);
+
+        final EventLoopGroup group = Mockito.mock(EventLoopGroup.class);
+        final Logger logger = Mockito.mock(Logger.class);
+        Mockito.when(logger.isDebugEnabled()).thenReturn(true);
+
+        final SmtpAsyncClient client = new SmtpAsyncClient(bootstrap, group, logger);
+        final SmtpAsyncSessionConfig config = new SmtpAsyncSessionConfig();
+        config.setConnectionTimeout(5000);
+        config.setReadTimeout(6000);
+
+        // test create session
+        final Future<SmtpAsyncCreateSessionResponse> future = client.createSession(
+                SmtpAsyncSessionData.newBuilder("smtp.foo.com", 993, true).setSessionContext("N/A").setSniNames(Collections.emptyList()).build(),
+                new SmtpAsyncSessionConfig(), SmtpAsyncSession.DebugMode.DEBUG_ON); // verify session creation
+
+        Assert.assertNotNull(future, "Future for SmtpAsyncSession should not be null.");
+        final ArgumentCaptor<SmtpClientChannelInitializer> initializerCaptor = ArgumentCaptor.forClass(SmtpClientChannelInitializer.class);
+
+        Mockito.verify(bootstrap, Mockito.times(1)).handler(initializerCaptor.capture());
+        Assert.assertEquals(initializerCaptor.getAllValues().size(), 1, "Unexpected count of SmtpClientChannelInitializer.");
+        final SmtpClientChannelInitializer initializer = initializerCaptor.getAllValues().get(0);
+
+        // should not call this connect
+        Mockito.verify(bootstrap, Mockito.times(0)).connect(Mockito.any(SocketAddress.class), Mockito.any(SocketAddress.class));
+        // should call following connect
+        Mockito.verify(bootstrap, Mockito.times(1)).connect(Mockito.anyString(), Mockito.anyInt());
+
+        final ArgumentCaptor<GenericFutureListener> listenerCaptor = ArgumentCaptor.forClass(GenericFutureListener.class);
+        Mockito.verify(nettyConnectFuture, Mockito.times(1)).addListener(listenerCaptor.capture());
+        Assert.assertEquals(listenerCaptor.getAllValues().size(), 1, "Unexpected count of SmtpClientChannelInitializer.");
+
+        // verify GenericFutureListener.operationComplete()
+        final GenericFutureListener listener = listenerCaptor.getAllValues().get(0);
+        listener.operationComplete(nettyConnectFuture);
+        final ArgumentCaptor<ChannelHandler> handlerCaptorFirst = ArgumentCaptor.forClass(ChannelHandler.class);
+
+        Mockito.verify(nettyPipeline, Mockito.times(0)).addFirst(Mockito.anyString(), handlerCaptorFirst.capture());
+        Assert.assertEquals(handlerCaptorFirst.getAllValues().size(), 0, "number of handlers mismatched.");
+        final ArgumentCaptor<ChannelHandler> handlerCaptorLast = ArgumentCaptor.forClass(ChannelHandler.class);
+        Mockito.verify(nettyPipeline, Mockito.times(0)).addLast(Mockito.anyString(), handlerCaptorLast.capture());
+        Assert.assertEquals(handlerCaptorLast.getAllValues().size(), 0, "Unexpected count of ChannelHandler added.");
+
+        // verify logging messages
+        // verify logging messages
+        Mockito.verify(logger, Mockito.times(1)).error(
+                Mockito.eq("[{},{}] connect operation complete. result={}, host={}, port={}, sslEnabled={}, sniNames={}"), Mockito.eq("N/A"),
+                Mockito.eq("N/A"), Mockito.eq("failure"), Mockito.eq("smtp.foo.com"), Mockito.eq(993), Mockito.eq(true),
+                Mockito.eq(Collections.emptyList()), Mockito.isA(SmtpAsyncClientException.class));
+        Assert.assertTrue(future.isDone(), "Future should be done.");
+        SmtpAsyncClientException actual = null;
+        try {
+            future.get(5, TimeUnit.SECONDS);
+            Assert.fail("Should throw connect timeout exception");
+        } catch (final ExecutionException | InterruptedException ex) {
+            Assert.assertNotNull(ex, "Expect exception to be thrown.");
+            Assert.assertNotNull(ex.getCause(), "Expect cause.");
+            Assert.assertEquals(ex.getClass(), ExecutionException.class, "Class type mismatch.");
+            final Exception exception = (Exception) ex.getCause();
+            Assert.assertEquals(exception.getClass(), SmtpAsyncClientException.class, "exception type mismatch." + ex);
+            actual = (SmtpAsyncClientException) exception;
+        }
+
+        Assert.assertNotNull(actual.getCause(), "Cause should not be null");
+        Assert.assertEquals(actual.getCause().getClass(), ConnectTimeoutException.class, "Cause should be connection timeout exception");
+        Assert.assertSame(actual.getCause(), nettyConnectFuture.cause(), "Cause should be same object");
+        Assert.assertEquals(actual.getFailureType(), FailureType.WRITE_TO_SERVER_FAILED, "Exception type should be CONNECTION_TIMEOUT_EXCEPTION");
+
+
     }
 
     /**

--- a/core/src/test/java/com/yahoo/smtpnio/async/netty/SmtpClientConnectHandlerTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/netty/SmtpClientConnectHandlerTest.java
@@ -260,8 +260,6 @@ public class SmtpClientConnectHandlerTest {
         handler.channelInactive(ctx);
     }
 
-
-
     /**
      * Tests {@code userEventTriggered} method and the event is {@link IdleStateEvent}, state is NOT {@code READ_IDLE}.
      *

--- a/core/src/test/java/com/yahoo/smtpnio/async/netty/SmtpClientConnectHandlerTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/netty/SmtpClientConnectHandlerTest.java
@@ -27,6 +27,7 @@ import com.yahoo.smtpnio.async.exception.SmtpAsyncClientException;
 import com.yahoo.smtpnio.async.exception.SmtpAsyncClientException.FailureType;
 import com.yahoo.smtpnio.async.response.SmtpResponse;
 
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.timeout.IdleState;
@@ -111,6 +112,9 @@ public class SmtpClientConnectHandlerTest {
         final ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
         final ChannelPipeline pipeline = Mockito.mock(ChannelPipeline.class);
         Mockito.when(ctx.pipeline()).thenReturn(pipeline);
+        final Channel channel = Mockito.mock(Channel.class);
+        Mockito.when(channel.isActive()).thenReturn(true);
+        Mockito.when(ctx.channel()).thenReturn(channel);
 
         final String msg = "504 some error response";
         final SmtpResponse resp = new SmtpResponse(msg);
@@ -131,6 +135,8 @@ public class SmtpClientConnectHandlerTest {
         Assert.assertNotNull(ex, "Expect exception to be thrown.");
         Assert.assertNotNull(ex.getCause(), "Expect cause.");
         Assert.assertEquals(ex.getCause().getClass(), SmtpAsyncClientException.class, "Expected result mismatched.");
+        Mockito.verify(ctx, Mockito.times(1)).close();
+        Mockito.verify(channel, Mockito.times(1)).isActive();
     }
 
     /**
@@ -149,6 +155,10 @@ public class SmtpClientConnectHandlerTest {
         final SmtpClientConnectHandler handler = new SmtpClientConnectHandler(smtpFuture, logger, DebugMode.DEBUG_ON, SESSION_ID, sessCtx);
 
         final ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
+        final Channel channel = Mockito.mock(Channel.class);
+        Mockito.when(channel.isActive()).thenReturn(true);
+        Mockito.when(ctx.channel()).thenReturn(channel);
+
         final TimeoutException timeoutEx = new TimeoutException("too late, my friend");
         handler.exceptionCaught(ctx, timeoutEx);
 
@@ -162,6 +172,46 @@ public class SmtpClientConnectHandlerTest {
         Assert.assertNotNull(ex, "Expect exception to be thrown.");
         Assert.assertNotNull(ex.getCause(), "Expect cause.");
         Assert.assertEquals(ex.getCause().getClass(), SmtpAsyncClientException.class, "Expected result mismatched.");
+
+        Mockito.verify(ctx, Mockito.times(1)).close();
+        Mockito.verify(channel, Mockito.times(1)).isActive();
+    }
+
+    /**
+     * Tests exceptionCaught method.
+     *
+     * @throws IllegalArgumentException will not throw
+     * @throws InterruptedException will not throw
+     * @throws TimeoutException will not throw
+     */
+    @Test
+    public void testExceptionCaughtChannelWasClosedAlready() throws IllegalArgumentException, InterruptedException, TimeoutException {
+        final SmtpFuture<SmtpAsyncCreateSessionResponse> smtpFuture = new SmtpFuture<SmtpAsyncCreateSessionResponse>();
+        final Logger logger = Mockito.mock(Logger.class);
+
+        final String sessCtx = "Titanosauria@long.neck";
+        final SmtpClientConnectHandler handler = new SmtpClientConnectHandler(smtpFuture, logger, DebugMode.DEBUG_ON, SESSION_ID, sessCtx);
+
+        final ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
+        final Channel channel = Mockito.mock(Channel.class);
+        Mockito.when(channel.isActive()).thenReturn(false); // return false to reflect channel closed
+        Mockito.when(ctx.channel()).thenReturn(channel);
+
+        final TimeoutException timeoutEx = new TimeoutException("too late, my friend");
+        handler.exceptionCaught(ctx, timeoutEx);
+
+        Assert.assertTrue(smtpFuture.isDone(), "Future should be done");
+        ExecutionException ex = null;
+        try {
+            smtpFuture.get(5, TimeUnit.MILLISECONDS);
+        } catch (final ExecutionException ee) {
+            ex = ee;
+        }
+        Assert.assertNotNull(ex, "Expect exception to be thrown.");
+        Assert.assertNotNull(ex.getCause(), "Expect cause.");
+        Assert.assertEquals(ex.getCause().getClass(), SmtpAsyncClientException.class, "Expected result mismatched.");
+        Mockito.verify(ctx, Mockito.times(0)).close(); // should not close since channel is already closed
+        Mockito.verify(channel, Mockito.times(1)).isActive();
     }
 
     /**
@@ -180,6 +230,9 @@ public class SmtpClientConnectHandlerTest {
         final SmtpClientConnectHandler handler = new SmtpClientConnectHandler(smtpFuture, logger, DebugMode.DEBUG_ON, SESSION_ID, sessCtx);
 
         final ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
+        final Channel channel = Mockito.mock(Channel.class);
+        Mockito.when(channel.isActive()).thenReturn(true);
+        Mockito.when(ctx.channel()).thenReturn(channel);
         final IdleStateEvent idleEvent = Mockito.mock(IdleStateEvent.class);
         Mockito.when(idleEvent.state()).thenReturn(IdleState.READER_IDLE);
         handler.userEventTriggered(ctx, idleEvent);
@@ -200,9 +253,14 @@ public class SmtpClientConnectHandlerTest {
         final SmtpAsyncClientException aEx = (SmtpAsyncClientException) cause;
         Assert.assertEquals(aEx.getFailureType(), FailureType.CONNECTION_FAILED_EXCEED_IDLE_MAX, "Failure type mismatched");
 
+        Mockito.verify(ctx, Mockito.times(1)).close();
+        Mockito.verify(channel, Mockito.times(1)).isActive();
+
         // call channelInactive, should not encounter npe
         handler.channelInactive(ctx);
     }
+
+
 
     /**
      * Tests {@code userEventTriggered} method and the event is {@link IdleStateEvent}, state is NOT {@code READ_IDLE}.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix a couple of exception cases that we miss to close the connection.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Channels should be closed in all cases to prevent memory leaking.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Add new test cases to cover methods for closing channel.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Major release (change is NOT backward compatible with prior release)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
