### PR TITLE
Upgrade travis CI env to ubuntu 20.04 Focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ branches:
   - stable
 language: java
 jdk:
-- oraclejdk8
-dist: trusty
+- openjdk11
+dist: focal
 before_install:
 install:
 - mvn clean install -Dgpg.skip=true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Upgrade travis CI env to ubuntu 20.04 Focal

## Motivation and Context
We are facing following error during
gpg: Invalid option "--pinentry-mode" which was introduced in 2.1
Installing latest CI env to get gnupg 2.2.19 installed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Major release (change is NOT backward compatible with prior release)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
