### PR TITLE
Remove additional permission limit for ci/deploy

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -2,7 +2,6 @@
 if [ "${TRAVIS_BRANCH}" == 'master' ] && [ "${TRAVIS_PULL_REQUEST}" == 'false' ]; then
     export GPG_TTY=$(tty)
     mkdir ci/deploy
-    chmod 0400 ci/deploy
 
     openssl aes-256-cbc -pass pass:$GPG_ENCPHRASE -in ci/pubring.gpg.enc -out ci/deploy/pubring.gpg -pbkdf2 -d
     openssl aes-256-cbc -pass pass:$GPG_ENCPHRASE -in ci/secring.gpg.enc -out ci/deploy/secring.gpg -pbkdf2 -d


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove additional permission limit for ci/deploy

## Motivation and Context
`Can't open ci/deploy/pubring.gpg for writing, Permission denied
140589766243648:error:0200100D:system library:fopen:Permission denied:../crypto/bio/bss_file.c:69:fopen('ci/deploy/pubring.gpg','wb')
140589766243648:error:2006D002:BIO routines:BIO_new_file:system lib:../crypto/bio/bss_file.c:78:
Can't open ci/deploy/secring.gpg for writing, Permission denied
140487112754496:error:0200100D:system library:fopen:Permission denied:../crypto/bio/bss_file.c:69:fopen('ci/deploy/secring.gpg','wb')
140487112754496:error:2006D002:BIO routines:BIO_new_file:system lib:../crypto/bio/bss_file.c:78:
gpg: can't open 'ci/deploy/pubring.gpg': Permission denied
gpg: Total number processed: 0
gpg: can't open 'ci/deploy/secring.gpg': Permission denied
gpg: Total number processed: 0`

## How Has This Been Tested?
Locally in Mac

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Major release (change is NOT backward compatible with prior release)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
