### PR TITLE
Inject SslContext via SmtpAsyncSessionData

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This library is built and managed using [maven](https://maven.apache.org/what-is
 <dependency>
   <groupId>com.yahoo.smtpnio</groupId>
   <artifactId>smtpnio.core</artifactId>
-  <version>1.0.7</version>
+  <version>1.0.8</version>
 </dependency>
 ```
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.yahoo.smtpnio</groupId>
         <artifactId>smtpnio</artifactId>
-        <version>1.0.7</version>
+        <version>1.0.8</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/core/src/main/java/com/yahoo/smtpnio/async/client/SmtpAsyncClient.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/client/SmtpAsyncClient.java
@@ -193,7 +193,7 @@ public class SmtpAsyncClient {
                 SslHandler sslHandler = null;
                 if (isSsl) {
                     try {
-                        sslHandler = createSSLHandler(ch.alloc(), host, port, sniNames);
+                        sslHandler = createSSLHandler(ch.alloc(), host, port, sniNames, sessionData.getSslContext());
                     } catch (final SSLException e) {
                         final SmtpAsyncClientException ex = new SmtpAsyncClientException(FailureType.SSL_CONTEXT_EXCEPTION, e);
                         handleSessionFailed(sessionId, sessionData, ex, sessionCreatedFuture, ch, isSsl);
@@ -289,8 +289,8 @@ public class SmtpAsyncClient {
      * @throws SSLException on SslContext creation error
      */
     static SslHandler createSSLHandler(@Nonnull final ByteBufAllocator alloc, @Nonnull final String host, final int port,
-            @Nullable final Collection<String> sniNames) throws SSLException {
-        final SslContext sslContext = SslContextBuilder.forClient().build();
+            @Nullable final Collection<String> sniNames, @Nullable SslContext sslCtxt) throws SSLException {
+        final SslContext sslContext = (sslCtxt == null) ? SslContextBuilder.forClient().build(): sslCtxt;
         if (sniNames != null && !sniNames.isEmpty()) { // SNI support
             final List<SNIServerName> serverNames = new ArrayList<>();
             for (final String sni : sniNames) {

--- a/core/src/main/java/com/yahoo/smtpnio/async/client/SmtpAsyncClient.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/client/SmtpAsyncClient.java
@@ -290,6 +290,7 @@ public class SmtpAsyncClient {
      */
     static SslHandler createSSLHandler(@Nonnull final ByteBufAllocator alloc, @Nonnull final String host, final int port,
             @Nullable final Collection<String> sniNames, @Nullable SslContext sslCtxt) throws SSLException {
+        // Use the passed SslContext only if non-null. Otherwise build a default client SslContext for use.
         final SslContext sslContext = (sslCtxt == null) ? SslContextBuilder.forClient().build(): sslCtxt;
         if (sniNames != null && !sniNames.isEmpty()) { // SNI support
             final List<SNIServerName> serverNames = new ArrayList<>();

--- a/core/src/main/java/com/yahoo/smtpnio/async/client/SmtpAsyncClient.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/client/SmtpAsyncClient.java
@@ -17,10 +17,13 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.net.ssl.SNIHostName;
 import javax.net.ssl.SNIServerName;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLParameters;
 
+import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.JdkSslContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -193,7 +196,7 @@ public class SmtpAsyncClient {
                 SslHandler sslHandler = null;
                 if (isSsl) {
                     try {
-                        sslHandler = createSSLHandler(ch.alloc(), host, port, sniNames, sessionData.getSslContext());
+                        sslHandler = createSSLHandler(ch.alloc(), host, port, sniNames, sessionData.getSSLContext());
                     } catch (final SSLException e) {
                         final SmtpAsyncClientException ex = new SmtpAsyncClientException(FailureType.SSL_CONTEXT_EXCEPTION, e);
                         handleSessionFailed(sessionId, sessionData, ex, sessionCreatedFuture, ch, isSsl);
@@ -285,13 +288,14 @@ public class SmtpAsyncClient {
      * @param host host name of server
      * @param port port of server
      * @param sniNames collection of SNI names
+     * @param sslCtxt Optional Custom SSLContext
      * @return a SslHandlerBuilder object used to build {@link SslHandler}
      * @throws SSLException on SslContext creation error
      */
     static SslHandler createSSLHandler(@Nonnull final ByteBufAllocator alloc, @Nonnull final String host, final int port,
-            @Nullable final Collection<String> sniNames, @Nullable SslContext sslCtxt) throws SSLException {
+            @Nullable final Collection<String> sniNames, @Nullable final SSLContext sslCtxt) throws SSLException {
         // Use the passed SslContext only if non-null. Otherwise build a default client SslContext for use.
-        final SslContext sslContext = (sslCtxt == null) ? SslContextBuilder.forClient().build(): sslCtxt;
+        final SslContext sslContext = (sslCtxt == null) ? SslContextBuilder.forClient().build() : new JdkSslContext(sslCtxt, true, ClientAuth.NONE);
         if (sniNames != null && !sniNames.isEmpty()) { // SNI support
             final List<SNIServerName> serverNames = new ArrayList<>();
             for (final String sni : sniNames) {

--- a/core/src/main/java/com/yahoo/smtpnio/async/client/SmtpAsyncSessionData.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/client/SmtpAsyncSessionData.java
@@ -4,13 +4,12 @@
  */
 package com.yahoo.smtpnio.async.client;
 
-import io.netty.handler.ssl.SslContext;
-
 import java.net.InetSocketAddress;
 import java.util.Collection;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.net.ssl.SSLContext;
 
 /**
  * This class defines session data associated with {@link SmtpAsyncClient}.
@@ -40,11 +39,11 @@ public final class SmtpAsyncSessionData {
     private final Object sessionContext;
 
     /**
-     * {@link SslContext} to be used for the session.
+     * {@link SSLContext} to be used for the session.
      *
      */
     @Nullable
-    private final SslContext sslContext;
+    private final SSLContext sslContext;
     /**
      * Builder class to build {@link SmtpAsyncSessionData} instances.
      */
@@ -72,9 +71,9 @@ public final class SmtpAsyncSessionData {
         @Nullable
         private Object sessionContext;
 
-        /** SslContext to be used for the session. */
+        /** SSLContext to be used for the session. */
         @Nullable
-        private SslContext sslContext;
+        private SSLContext sslContext;
 
         /**
          * Initializes a builder for {@link SmtpAsyncSessionData}.
@@ -120,7 +119,7 @@ public final class SmtpAsyncSessionData {
          * @param sslCtx Ssl context
          * @return {@code this} object for chaining
          */
-        public DataBuilder setSslContext(@Nonnull final SslContext sslCtx) {
+        public DataBuilder setSSLContext(@Nonnull final SSLContext sslCtx) {
             this.sslContext = sslCtx;
             return this;
         }
@@ -160,7 +159,7 @@ public final class SmtpAsyncSessionData {
      */
     private SmtpAsyncSessionData(@Nonnull final String host, final int port, final boolean enableSsl, @Nullable final Collection<String> sniNames,
                                  @Nullable final InetSocketAddress localAddress, @Nullable final Object sessionCtx,
-                                 @Nullable final SslContext sslCtx) {
+                                 @Nullable final SSLContext sslCtx) {
         this.host = host;
         this.port = port;
         this.enableSsl = enableSsl;
@@ -220,7 +219,7 @@ public final class SmtpAsyncSessionData {
      * @return Ssl context
      */
     @Nullable
-    public SslContext getSslContext() {
+    public SSLContext getSSLContext() {
         return sslContext;
     }
 

--- a/core/src/main/java/com/yahoo/smtpnio/async/client/SmtpAsyncSessionData.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/client/SmtpAsyncSessionData.java
@@ -4,6 +4,8 @@
  */
 package com.yahoo.smtpnio.async.client;
 
+import io.netty.handler.ssl.SslContext;
+
 import java.net.InetSocketAddress;
 import java.util.Collection;
 
@@ -38,6 +40,12 @@ public final class SmtpAsyncSessionData {
     private final Object sessionContext;
 
     /**
+     * {@link SslContext} to be used for the session.
+     *
+     */
+    @Nullable
+    private final SslContext sslContext;
+    /**
      * Builder class to build {@link SmtpAsyncSessionData} instances.
      */
     public static final class DataBuilder {
@@ -63,6 +71,10 @@ public final class SmtpAsyncSessionData {
         /** Context associated with the session. */
         @Nullable
         private Object sessionContext;
+
+        /** SslContext to be used for the session. */
+        @Nullable
+        private SslContext sslContext;
 
         /**
          * Initializes a builder for {@link SmtpAsyncSessionData}.
@@ -105,12 +117,21 @@ public final class SmtpAsyncSessionData {
         }
 
         /**
+         * @param sslCtx Ssl context
+         * @return {@code this} object for chaining
+         */
+        public DataBuilder setSslContext(@Nonnull final SslContext sslCtx) {
+            this.sslContext = sslCtx;
+            return this;
+        }
+
+        /**
          * Builds the {@link SmtpAsyncSessionData} with the set properties.
          *
          * @return an {@link SmtpAsyncSessionData} instance
          */
         public SmtpAsyncSessionData build() {
-            return new SmtpAsyncSessionData(host, port, enableSsl, sniNames, localAddress, sessionContext);
+            return new SmtpAsyncSessionData(host, port, enableSsl, sniNames, localAddress, sessionContext, sslContext);
         }
     }
 
@@ -135,15 +156,18 @@ public final class SmtpAsyncSessionData {
      * @param sniNames collection of SNI names
      * @param localAddress local address to be used
      * @param sessionCtx session context
+     * @param sslCtx Ssl Context to be used
      */
     private SmtpAsyncSessionData(@Nonnull final String host, final int port, final boolean enableSsl, @Nullable final Collection<String> sniNames,
-                                 @Nullable final InetSocketAddress localAddress, @Nullable final Object sessionCtx) {
+                                 @Nullable final InetSocketAddress localAddress, @Nullable final Object sessionCtx,
+                                 @Nullable final SslContext sslCtx) {
         this.host = host;
         this.port = port;
         this.enableSsl = enableSsl;
         this.sniNames = sniNames;
         this.localAddress = localAddress;
         this.sessionContext = sessionCtx;
+        this.sslContext = sslCtx;
     }
 
     /**
@@ -191,4 +215,13 @@ public final class SmtpAsyncSessionData {
     public Object getSessionContext() {
         return sessionContext;
     }
+
+    /**
+     * @return Ssl context
+     */
+    @Nullable
+    public SslContext getSslContext() {
+        return sslContext;
+    }
+
 }

--- a/core/src/main/java/com/yahoo/smtpnio/async/client/StarttlsHandler.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/client/StarttlsHandler.java
@@ -221,7 +221,7 @@ public class StarttlsHandler extends MessageToMessageDecoder<SmtpResponse> {
                 try {
                     // create sslHandler
                     final SslHandler sslHandler = SmtpAsyncClient.createSSLHandler(ctx.alloc(), this.sessionData.getHost(),
-                            this.sessionData.getPort(), this.sessionData.getSniNames(), this.sessionData.getSslContext());
+                            this.sessionData.getPort(), this.sessionData.getSniNames(), this.sessionData.getSSLContext());
                     // add listener to check if ssl connection succeeds
                     sslHandler.handshakeFuture().addListener(new SSLHandShakeCompleteListener(serverResponse, ctx));
                     ctx.pipeline().addFirst(SSL_HANDLER_NAME, sslHandler);

--- a/core/src/main/java/com/yahoo/smtpnio/async/client/StarttlsHandler.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/client/StarttlsHandler.java
@@ -221,7 +221,7 @@ public class StarttlsHandler extends MessageToMessageDecoder<SmtpResponse> {
                 try {
                     // create sslHandler
                     final SslHandler sslHandler = SmtpAsyncClient.createSSLHandler(ctx.alloc(), this.sessionData.getHost(),
-                            this.sessionData.getPort(), this.sessionData.getSniNames());
+                            this.sessionData.getPort(), this.sessionData.getSniNames(), this.sessionData.getSslContext());
                     // add listener to check if ssl connection succeeds
                     sslHandler.handshakeFuture().addListener(new SSLHandShakeCompleteListener(serverResponse, ctx));
                     ctx.pipeline().addFirst(SSL_HANDLER_NAME, sslHandler);

--- a/core/src/test/java/com/yahoo/smtpnio/async/client/SmtpAsyncClientTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/client/SmtpAsyncClientTest.java
@@ -16,6 +16,8 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import javax.net.ssl.SSLException;
 
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.internal.util.reflection.Whitebox;
@@ -74,13 +76,13 @@ public class SmtpAsyncClientTest {
         final Logger logger = Mockito.mock(Logger.class);
 
         final SmtpAsyncClient client = new SmtpAsyncClient(bootstrap, group, logger);
-
         client.createSession(SmtpAsyncSessionData.newBuilder(null, 465, true).build(), new SmtpAsyncSessionConfig(),
                 SmtpAsyncSession.DebugMode.DEBUG_OFF);
     }
 
     /**
      * Tests the behavior of {@code createSession} on a successful SSL connection.
+     * This uses an "injected" default SSLContext.
      *
      * @throws Exception will not throw in this test
      */
@@ -100,8 +102,9 @@ public class SmtpAsyncClientTest {
         Mockito.when(logger.isTraceEnabled()).thenReturn(false);
 
         final SmtpAsyncClient client = new SmtpAsyncClient(bootstrap, group, logger);
+        final SslContext sslContext = SslContextBuilder.forClient().build();
         final SmtpAsyncSessionData sessionData = SmtpAsyncSessionData.newBuilder("smtp.one.two.three.com", 993, true).setSessionContext(
-                "myCtx")
+                "myCtx").setSslContext(sslContext)
                 .build();
 
         final Future<SmtpAsyncCreateSessionResponse> future = client.createSession(sessionData, new SmtpAsyncSessionConfig().setEnableStarttls(true),

--- a/core/src/test/java/com/yahoo/smtpnio/async/client/SmtpAsyncClientTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/client/SmtpAsyncClientTest.java
@@ -14,10 +14,9 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
 
-import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.internal.util.reflection.Whitebox;
@@ -102,9 +101,9 @@ public class SmtpAsyncClientTest {
         Mockito.when(logger.isTraceEnabled()).thenReturn(false);
 
         final SmtpAsyncClient client = new SmtpAsyncClient(bootstrap, group, logger);
-        final SslContext sslContext = SslContextBuilder.forClient().build();
+        final SSLContext sslContext = SSLContext.getDefault();
         final SmtpAsyncSessionData sessionData = SmtpAsyncSessionData.newBuilder("smtp.one.two.three.com", 993, true).setSessionContext(
-                "myCtx").setSslContext(sslContext)
+                "myCtx").setSSLContext(sslContext)
                 .build();
 
         final Future<SmtpAsyncCreateSessionResponse> future = client.createSession(sessionData, new SmtpAsyncSessionConfig().setEnableStarttls(true),

--- a/core/src/test/java/com/yahoo/smtpnio/async/client/SmtpAsyncSessionDataTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/client/SmtpAsyncSessionDataTest.java
@@ -9,15 +9,10 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.List;
 
-import io.netty.handler.ssl.ClientAuth;
-import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
-import io.netty.handler.ssl.SslProvider;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 
 /**
@@ -37,7 +32,7 @@ public class SmtpAsyncSessionDataTest {
         Assert.assertNull(data.getSniNames(), "SNI name list should be null");
         Assert.assertNull(data.getLocalAddress(), "local address should be null");
         Assert.assertNull(data.getSessionContext(), "session context should be null");
-        Assert.assertNull(data.getSslContext(), "Ssl context should be null");
+        Assert.assertNull(data.getSSLContext(), "Ssl context should be null");
     }
 
     /**
@@ -52,15 +47,11 @@ public class SmtpAsyncSessionDataTest {
         final String context = "UnitTest101";
         final List<String> sniNames = Arrays.asList("Sni1", "Sni2");
         final SSLContext sslCtxt = SSLContext.getDefault();
-        SslContext sslContext = SslContextBuilder.forClient()
-                .sslProvider(SslProvider.JDK).clientAuth(ClientAuth.NONE)
-                .ciphers(Arrays.asList(sslCtxt.getDefaultSSLParameters().getCipherSuites()))
-                .build();
         final SmtpAsyncSessionData data = SmtpAsyncSessionData.newBuilder("my_host.smtp.org", 587, false)
                 .setSniNames(sniNames)
                 .setLocalAddress(localAddress)
                 .setSessionContext(context)
-                .setSslContext(sslContext)
+                .setSSLContext(sslCtxt)
                 .build();
 
         Assert.assertEquals(data.getHost(), "my_host.smtp.org", "Unexpected host");
@@ -69,6 +60,6 @@ public class SmtpAsyncSessionDataTest {
         Assert.assertSame(data.getSniNames(), sniNames, "SNI name list should be same");
         Assert.assertSame(data.getLocalAddress(), localAddress, "local address should be same");
         Assert.assertEquals(data.getSessionContext(), "UnitTest101", "session context should match");
-        Assert.assertSame(data.getSslContext(), sslContext, "Ssl context should be same");
+        Assert.assertSame(data.getSSLContext(), sslCtxt, "Ssl context should be same");
     }
 }

--- a/core/src/test/java/com/yahoo/smtpnio/async/client/SmtpAsyncSessionDataTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/client/SmtpAsyncSessionDataTest.java
@@ -5,11 +5,20 @@
 package com.yahoo.smtpnio.async.client;
 
 import java.net.InetSocketAddress;
+import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.List;
 
+import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLException;
 
 /**
  * Unit test for {@link SmtpAsyncSessionData}.
@@ -28,27 +37,38 @@ public class SmtpAsyncSessionDataTest {
         Assert.assertNull(data.getSniNames(), "SNI name list should be null");
         Assert.assertNull(data.getLocalAddress(), "local address should be null");
         Assert.assertNull(data.getSessionContext(), "session context should be null");
+        Assert.assertNull(data.getSslContext(), "Ssl context should be null");
     }
 
     /**
      * Tests the correctness of the setters.
+     *
+     * @throws NoSuchAlgorithmException Does not throw
+     * @throws SSLException Does not throw
      */
     @Test
-    public void testSetters() {
+    public void testSetters() throws NoSuchAlgorithmException, SSLException {
         final InetSocketAddress localAddress = new InetSocketAddress("localhost", 65535);
         final String context = "UnitTest101";
         final List<String> sniNames = Arrays.asList("Sni1", "Sni2");
+        final SSLContext sslCtxt = SSLContext.getDefault();
+        SslContext sslContext = SslContextBuilder.forClient()
+                .sslProvider(SslProvider.JDK).clientAuth(ClientAuth.NONE)
+                .ciphers(Arrays.asList(sslCtxt.getDefaultSSLParameters().getCipherSuites()))
+                .build();
         final SmtpAsyncSessionData data = SmtpAsyncSessionData.newBuilder("my_host.smtp.org", 587, false)
                 .setSniNames(sniNames)
                 .setLocalAddress(localAddress)
                 .setSessionContext(context)
+                .setSslContext(sslContext)
                 .build();
 
         Assert.assertEquals(data.getHost(), "my_host.smtp.org", "Unexpected host");
         Assert.assertEquals(data.getPort(), 587, "Unexpected port number");
         Assert.assertFalse(data.isSslEnabled(), "Unexpected SSL flag");
-        Assert.assertSame(data.getSniNames(), sniNames, "SNI name list should be null");
-        Assert.assertSame(data.getLocalAddress(), localAddress, "local address should be null");
-        Assert.assertEquals(data.getSessionContext(), "UnitTest101", "session context should be null");
+        Assert.assertSame(data.getSniNames(), sniNames, "SNI name list should be same");
+        Assert.assertSame(data.getLocalAddress(), localAddress, "local address should be same");
+        Assert.assertEquals(data.getSessionContext(), "UnitTest101", "session context should match");
+        Assert.assertSame(data.getSslContext(), sslContext, "Ssl context should be same");
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.yahoo.smtpnio</groupId>
     <artifactId>smtpnio</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.7</version>
+    <version>1.0.8</version>
     <name>${project.artifactId}</name>
     <url>https://github.com/yahoo/smtp-client-nio</url>
     <description>Parent POM file for smtpnio project</description>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Ability to inject custom SslContext using SmtpAsyncSessionData for creating
secure SMTP session.

## Description

See [Issue-30](https://github.com/yahoo/smtp-client-nio/issues/30) for description

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allows custom SslContext to be injected for secure SMTP session.

<!--- If it fixes an open issue, please link to the issue here. -->
[Issue-30](https://github.com/yahoo/smtp-client-nio/issues/30)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Existing tests have been updated.

<!--- Include details of your testing environment, and the tests you ran to -->
MacOS + JDK15.

<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Major release (change is NOT backward compatible with prior release)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
