### PR TITLE
ISSUE-32 Allow callbacks in SmtpFuture

### DIFF
--- a/core/src/main/java/com/yahoo/smtpnio/async/client/SmtpAsyncClient.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/client/SmtpAsyncClient.java
@@ -118,7 +118,7 @@ public class SmtpAsyncClient {
      * @param debugOption the debugging option used
      * @return the future containing the result of the request
      */
-    public SmtpFuture<SmtpAsyncCreateSessionResponse> createSession(@Nonnull final SmtpAsyncSessionData sessionData,
+    public Future<SmtpAsyncCreateSessionResponse> createSession(@Nonnull final SmtpAsyncSessionData sessionData,
             @Nonnull final SmtpAsyncSessionConfig config, @Nonnull final SmtpAsyncSession.DebugMode debugOption) {
         bootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, config.getConnectionTimeout());
         final SmtpFuture<SmtpAsyncCreateSessionResponse> sessionCreatedFuture = new SmtpFuture<>();

--- a/core/src/main/java/com/yahoo/smtpnio/async/client/SmtpAsyncClient.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/client/SmtpAsyncClient.java
@@ -118,7 +118,7 @@ public class SmtpAsyncClient {
      * @param debugOption the debugging option used
      * @return the future containing the result of the request
      */
-    public Future<SmtpAsyncCreateSessionResponse> createSession(@Nonnull final SmtpAsyncSessionData sessionData,
+    public SmtpFuture<SmtpAsyncCreateSessionResponse> createSession(@Nonnull final SmtpAsyncSessionData sessionData,
             @Nonnull final SmtpAsyncSessionConfig config, @Nonnull final SmtpAsyncSession.DebugMode debugOption) {
         bootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, config.getConnectionTimeout());
         final SmtpFuture<SmtpAsyncCreateSessionResponse> sessionCreatedFuture = new SmtpFuture<>();

--- a/core/src/test/java/com/yahoo/smtpnio/async/client/SmtpFutureTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/client/SmtpFutureTest.java
@@ -15,6 +15,8 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
@@ -184,4 +186,347 @@ public class SmtpFutureTest {
         final long mockTimeoutForFailure = 1L;
         smtpFuture.get(mockTimeoutForFailure, TimeUnit.MILLISECONDS);
     }
+
+    /**
+     * Tests to verify error callback is not called when the future is cancelled.
+     */
+    @Test
+    public void testFutureErrorCallbackUponCancelled() {
+        final AtomicBoolean called = new AtomicBoolean(false);
+        final SmtpFuture<SmtpAsyncResponse> smtpFuture = new SmtpFuture<SmtpAsyncResponse>();
+        smtpFuture.setExceptionCallback(new Consumer<Exception>() {
+            @Override
+            public void accept(final Exception e) {
+                called.set(true);
+            }
+        });
+        smtpFuture.cancel(true);
+
+        Assert.assertFalse(called.get(), "Callback should not be run");
+    }
+
+    /**
+     * Tests to verify error callback is not called when the future is done.
+     */
+    @Test
+    public void testFutureErrorCallbackUponDone() {
+        final AtomicBoolean called = new AtomicBoolean(false);
+        final SmtpFuture<Boolean> smtpFuture = new SmtpFuture<Boolean>();
+        smtpFuture.setExceptionCallback(new Consumer<Exception>() {
+            @Override
+            public void accept(final Exception e) {
+                called.set(true);
+            }
+        });
+        smtpFuture.done(false);
+
+        Assert.assertFalse(called.get(), "Callback should not be run");
+    }
+
+    /**
+     * Tests to verify error callback is called when the future fails.
+     */
+    @Test
+    public void testFutureErrorCallbackUponException() {
+        final AtomicBoolean called = new AtomicBoolean(false);
+        final SmtpFuture<Boolean> smtpFuture = new SmtpFuture<Boolean>();
+        smtpFuture.setExceptionCallback(new Consumer<Exception>() {
+            @Override
+            public void accept(final Exception e) {
+                called.set(true);
+            }
+        });
+        smtpFuture.done(new RuntimeException());
+
+        Assert.assertTrue(called.get(), "Callback should be run");
+    }
+
+    /**
+     * Tests to verify done callback is not called when the future is cancelled.
+     */
+    @Test
+    public void testFutureDoneCallbackUponCancelled() {
+        final AtomicBoolean called = new AtomicBoolean(false);
+        final SmtpFuture<SmtpAsyncResponse> smtpFuture = new SmtpFuture<SmtpAsyncResponse>();
+        smtpFuture.setDoneCallback(new Consumer<SmtpAsyncResponse>() {
+            @Override
+            public void accept(final SmtpAsyncResponse imapAsyncResponse) {
+                called.set(true);
+            }
+        });
+        smtpFuture.cancel(true);
+
+        Assert.assertFalse(called.get(), "Callback should not be run");
+    }
+
+    /**
+     * Tests to verify done callback is called when the future is done.
+     */
+    @Test
+    public void testFutureDoneCallbackUponDone() {
+        final AtomicBoolean called = new AtomicBoolean(false);
+        final SmtpFuture<Boolean> smtpFuture = new SmtpFuture<Boolean>();
+        smtpFuture.setDoneCallback(new Consumer<Boolean>() {
+            @Override
+            public void accept(final Boolean r) {
+                called.set(true);
+            }
+        });
+        smtpFuture.done(false);
+
+        Assert.assertTrue(called.get(), "Callback should be run");
+    }
+
+    /**
+     * Tests to verify done callback is not called when the future fails.
+     */
+    @Test
+    public void testFutureDoneCallbackUponException() {
+        final AtomicBoolean called = new AtomicBoolean(false);
+        final SmtpFuture<Boolean> smtpFuture = new SmtpFuture<Boolean>();
+        smtpFuture.setDoneCallback(new Consumer<Boolean>() {
+            @Override
+            public void accept(final Boolean r) {
+                called.set(true);
+            }
+        });
+        smtpFuture.done(new RuntimeException());
+
+        Assert.assertFalse(called.get(), "Callback should not be run");
+    }
+
+    /**
+     * Tests to verify cancel callback is called when the future is cancelled.
+     */
+    @Test
+    public void testFutureCancelCallbackUponCancelled() {
+        final AtomicBoolean called = new AtomicBoolean(false);
+        final SmtpFuture<SmtpAsyncResponse> smtpFuture = new SmtpFuture<SmtpAsyncResponse>();
+        smtpFuture.setCanceledCallback(new Runnable() {
+            @Override
+            public void run() {
+                called.set(true);
+            }
+        });
+        smtpFuture.cancel(true);
+
+        Assert.assertTrue(called.get(), "Callback should be run");
+    }
+
+    /**
+     * Tests to verify cancel callback is not called when the future is done.
+     */
+    @Test
+    public void testFutureCancelCallbackUponDone() {
+        final AtomicBoolean called = new AtomicBoolean(false);
+        final SmtpFuture<Boolean> smtpFuture = new SmtpFuture<Boolean>();
+        smtpFuture.setCanceledCallback(new Runnable() {
+            @Override
+            public void run() {
+                called.set(true);
+            }
+        });
+        smtpFuture.done(false);
+
+        Assert.assertFalse(called.get(), "Callback should not be run");
+    }
+
+    /**
+     * Tests to verify cancel callback is not called when the future fails.
+     */
+    @Test
+    public void testFutureCancelCallbackUponException() {
+        final AtomicBoolean called = new AtomicBoolean(false);
+        final SmtpFuture<Boolean> smtpFuture = new SmtpFuture<Boolean>();
+        smtpFuture.setCanceledCallback(new Runnable() {
+            @Override
+            public void run() {
+                called.set(true);
+            }
+        });
+        smtpFuture.done(new RuntimeException());
+
+        Assert.assertFalse(called.get(), "Callback should not be run");
+    }
+
+    /**
+     * Tests to verify error callback is not called when the future is cancelled.
+     *
+     * The future execution is already finished when the callback is registered.
+     */
+    @Test
+    public void testFutureErrorCallbackUponCancelledWhenFinished() {
+        final AtomicBoolean called = new AtomicBoolean(false);
+        final SmtpFuture<SmtpAsyncResponse> smtpFuture = new SmtpFuture<SmtpAsyncResponse>();
+        smtpFuture.cancel(true);
+        smtpFuture.setExceptionCallback(new Consumer<Exception>() {
+            @Override
+            public void accept(final Exception e) {
+                called.set(true);
+            }
+        });
+
+        Assert.assertFalse(called.get(), "Callback should not be run");
+    }
+
+    /**
+     * Tests to verify error callback is not called when the future is done.
+     *
+     * The future execution is already finished when the callback is registered.
+     */
+    @Test
+    public void testFutureErrorCallbackUponDoneWhenFinished() {
+        final AtomicBoolean called = new AtomicBoolean(false);
+        final SmtpFuture<Boolean> smtpFuture = new SmtpFuture<Boolean>();
+        smtpFuture.done(false);
+        smtpFuture.setExceptionCallback(new Consumer<Exception>() {
+            @Override
+            public void accept(final Exception e) {
+                called.set(true);
+            }
+        });
+
+        Assert.assertFalse(called.get(), "Callback should not be run");
+    }
+
+    /**
+     * Tests to verify error callback is called when the future fails.
+     *
+     * The future execution is already finished when the callback is registered.
+     */
+    @Test
+    public void testFutureErrorCallbackUponExceptionWhenFinished() {
+        final AtomicBoolean called = new AtomicBoolean(false);
+        final SmtpFuture<Boolean> smtpFuture = new SmtpFuture<Boolean>();
+        smtpFuture.done(new RuntimeException());
+        smtpFuture.setExceptionCallback(new Consumer<Exception>() {
+            @Override
+            public void accept(final Exception e) {
+                called.set(true);
+            }
+        });
+
+        Assert.assertTrue(called.get(), "Callback should be run");
+    }
+
+    /**
+     * Tests to verify done callback is not called when the future is cancelled.
+     *
+     * The future execution is already finished when the callback is registered.
+     */
+    @Test
+    public void testFutureDoneCallbackUponCancelledWhenFinished() {
+        final AtomicBoolean called = new AtomicBoolean(false);
+        final SmtpFuture<SmtpAsyncResponse> smtpFuture = new SmtpFuture<SmtpAsyncResponse>();
+        smtpFuture.cancel(true);
+        smtpFuture.setDoneCallback(new Consumer<SmtpAsyncResponse>() {
+            @Override
+            public void accept(final SmtpAsyncResponse imapAsyncResponse) {
+                called.set(true);
+            }
+        });
+
+        Assert.assertFalse(called.get(), "Callback should not be run");
+    }
+
+    /**
+     * Tests to verify done callback is called when the future is done.
+     *
+     * The future execution is already finished when the callback is registered.
+     */
+    @Test
+    public void testFutureDoneCallbackUponDoneWhenFinished() {
+        final AtomicBoolean called = new AtomicBoolean(false);
+        final SmtpFuture<Boolean> smtpFuture = new SmtpFuture<Boolean>();
+        smtpFuture.done(false);
+        smtpFuture.setDoneCallback(new Consumer<Boolean>() {
+            @Override
+            public void accept(final Boolean r) {
+                called.set(true);
+            }
+        });
+
+        Assert.assertTrue(called.get(), "Callback should be run");
+    }
+
+    /**
+     * Tests to verify done callback is not called when the future fails.
+     *
+     * The future execution is already finished when the callback is registered.
+     */
+    @Test
+    public void testFutureDoneCallbackUponExceptionWhenFinished() {
+        final AtomicBoolean called = new AtomicBoolean(false);
+        final SmtpFuture<Boolean> smtpFuture = new SmtpFuture<Boolean>();
+        smtpFuture.done(new RuntimeException());
+        smtpFuture.setDoneCallback(new Consumer<Boolean>() {
+            @Override
+            public void accept(final Boolean r) {
+                called.set(true);
+            }
+        });
+
+        Assert.assertFalse(called.get(), "Callback should not be run");
+    }
+
+    /**
+     * Tests to verify cancel callback is called when the future is cancelled.
+     *
+     * The future execution is already finished when the callback is registered.
+     */
+    @Test
+    public void testFutureCancelCallbackUponCancelledWhenFinished() {
+        final AtomicBoolean called = new AtomicBoolean(false);
+        final SmtpFuture<SmtpAsyncResponse> smtpFuture = new SmtpFuture<SmtpAsyncResponse>();
+        smtpFuture.cancel(true);
+        smtpFuture.setCanceledCallback(new Runnable() {
+            @Override
+            public void run() {
+                called.set(true);
+            }
+        });
+
+        Assert.assertTrue(called.get(), "Callback should be run");
+    }
+
+    /**
+     * Tests to verify cancel callback is not called when the future is done.
+     *
+     * The future execution is already finished when the callback is registered.
+     */
+    @Test
+    public void testFutureCancelCallbackUponDoneWhenFinished() {
+        final AtomicBoolean called = new AtomicBoolean(false);
+        final SmtpFuture<Boolean> smtpFuture = new SmtpFuture<Boolean>();
+        smtpFuture.done(false);
+        smtpFuture.setCanceledCallback(new Runnable() {
+            @Override
+            public void run() {
+                called.set(true);
+            }
+        });
+
+        Assert.assertFalse(called.get(), "Callback should not be run");
+    }
+
+    /**
+     * Tests to verify cancel callback is not called when the future fails.
+     *
+     * The future execution is already finished when the callback is registered.
+     */
+    @Test
+    public void testFutureCancelCallbackUponExceptionWhenFinished() {
+        final AtomicBoolean called = new AtomicBoolean(false);
+        final SmtpFuture<Boolean> smtpFuture = new SmtpFuture<Boolean>();
+        smtpFuture.done(new RuntimeException());
+        smtpFuture.setCanceledCallback(new Runnable() {
+            @Override
+            public void run() {
+                called.set(true);
+            }
+        });
+
+        Assert.assertFalse(called.get(), "Callback should not be run");
+    }
+
 }


### PR DESCRIPTION
This allow avoiding blocking in calling code to unwrap the future
and access the inner value. This empowers reactive/asynchronous/actor
systems integrations.

I chose the callback approach instead of using CompletableFuture in
order to minimize code changes.

## Description

Adds callbacks to SmtpFuture

Similar to https://github.com/yahoo/imapnio/pull/118

## Motivation and Context

Needs to call SmtpFuture.get to do anything usefull with this library however it blocks and defeat any reactive/asynchronous/actor system use of this library.

## How Has This Been Tested?

Unit test. I will also ensure timely that this solves my original issue.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Major release (change is NOT backward compatible with prior release)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
