### PR TITLE
 Other command for SMTP nio library

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This library is built and managed using [maven](https://maven.apache.org/what-is
 <dependency>
   <groupId>com.yahoo.smtpnio</groupId>
   <artifactId>smtpnio.core</artifactId>
-  <version>1.0.10</version>
+  <version>1.1.0</version>
 </dependency>
 ```
 
@@ -167,7 +167,20 @@ Version 1.0.4 adds startTls support.
 > 2. Then send STARTTLS command and check if response code is 220.
 > 3. Finally, upgrade plain connection to secure connection.
 
-
+This release, version 1.1.0, is the second official release. After this release, current supported SMTP commands are:
+- **EHLO**
+- **HELO**
+- **AUTH** (PLAIN, LOGIN, XOAUTH2)
+- **DATA**
+- **EXPN**
+- **HELO**
+- **MAIL**
+- **HELP**
+- **NOOP**
+- **VRFY**
+- **RSET**
+- **RCPT**
+- **QUIT**
 
 ## Contribute
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -128,6 +128,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>9</source>
+                    <target>9</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.yahoo.smtpnio</groupId>
         <artifactId>smtpnio</artifactId>
-        <version>1.0.10</version>
+        <version>1.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/core/src/main/java/com/yahoo/smtpnio/async/client/SmtpAsyncClient.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/client/SmtpAsyncClient.java
@@ -43,12 +43,15 @@ import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
+import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.util.concurrent.GenericFutureListener;
 
 /**
  * Implementation for the SMTP NIO client.
  */
 public class SmtpAsyncClient {
+
+    private static final String CHUNKED_WRITER = "chunked-writer";
 
     /** Enum used to specify different session mode. */
     private enum SessionMode {
@@ -224,6 +227,7 @@ public class SmtpAsyncClient {
                     pipeline.addFirst(SSL_HANDLER, sslHandler);
                     pipeline.addAfter(SSL_HANDLER, SslDetectHandler.HANDLER_NAME, new SslDetectHandler(sessionCount.get(), sessionData, config,
                             debugOption, smtpAsyncClient, sessionCreatedFuture));
+                    pipeline.addLast(CHUNKED_WRITER, new ChunkedWriteHandler());
                     pipeline.addLast(SmtpClientConnectHandler.HANDLER_NAME, new SmtpClientConnectHandler(sessionCreatedFuture,
                             debugOption, sessionId, sessionCtx));
                     break;

--- a/core/src/main/java/com/yahoo/smtpnio/async/client/SmtpClientChannelInitializer.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/client/SmtpClientChannelInitializer.java
@@ -14,12 +14,16 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.string.StringDecoder;
 import io.netty.handler.codec.string.StringEncoder;
+import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.handler.timeout.IdleStateHandler;
 
 /**
  * This class initializes the pipeline with the correct handlers.
  */
 final class SmtpClientChannelInitializer extends ChannelInitializer<SocketChannel> {
+
+    /** Handler name for chunked write handler. */
+    private static final String CHUNKED_WRITER = "chunked-writer";
 
     /** Handler name for idle sate handler. */
     private static final String IDLE_STATE_HANDLER_NAME = "idleStateHandler";
@@ -60,6 +64,7 @@ final class SmtpClientChannelInitializer extends ChannelInitializer<SocketChanne
         pipeline.addLast(SMTP_LINE_DECODER_HANDLER_NAME, new SmtpClientRespReader(Integer.MAX_VALUE));
         pipeline.addLast(STRING_DECODER_HANDLER_NAME, new StringDecoder());
         pipeline.addLast(STRING_ENCODER_HANDLER_NAME, new StringEncoder());
+        pipeline.addLast(CHUNKED_WRITER, new ChunkedWriteHandler());
         pipeline.addLast(STRING_SMTP_MSG_RESPONSE_NAME, new SmtpClientRespDecoder());
     }
 }

--- a/core/src/main/java/com/yahoo/smtpnio/async/internal/SmtpAsyncSessionImpl.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/internal/SmtpAsyncSessionImpl.java
@@ -267,9 +267,6 @@ public class SmtpAsyncSessionImpl implements SmtpAsyncSession, SmtpCommandChanne
             logger.debug(CLIENT_LOG_REC, sessionId, getUserInfo(),
                     (!command.isCommandLineDataSensitive()) ? request.toString(StandardCharsets.UTF_8) : command.getDebugData());
         }
-        if (isChannelClosed()) {
-            throw new SmtpAsyncClientException(FailureType.OPERATION_PROHIBITED_ON_CLOSED_CHANNEL, sessionId, sessionCtx);
-        }
 
         // ChannelPromise is the suggested ChannelFuture that allows caller to setup listener before the action is made
         // this is useful for light-speed operation.

--- a/core/src/main/java/com/yahoo/smtpnio/async/internal/SmtpAsyncSessionImpl.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/internal/SmtpAsyncSessionImpl.java
@@ -301,6 +301,12 @@ public class SmtpAsyncSessionImpl implements SmtpAsyncSession, SmtpCommandChanne
         command.encodeCommandAfterContinuation(channel, writeFuture(channel), serverResponse);
     }
 
+    /**
+     * Allows creating a channel promise provider, to be used upon writes.
+     *
+     * @param channel A channel.
+     * @return a way to obtain channel proses calling back this session, for the supplied channel.
+     */
     private Supplier<ChannelPromise> writeFuture(final Channel channel) {
         SmtpAsyncSessionImpl session = this;
         return new Supplier<ChannelPromise>() {

--- a/core/src/main/java/com/yahoo/smtpnio/async/internal/SmtpAsyncSessionImpl.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/internal/SmtpAsyncSessionImpl.java
@@ -411,7 +411,6 @@ public class SmtpAsyncSessionImpl implements SmtpAsyncSession, SmtpCommandChanne
         // server sends continuation message for next request. Eg. DATA command
         if (serverResponse.isContinuation()) {
             try {
-                curEntry.setState(SmtpCommandEntry.CommandState.RESPONSES_DONE);
                 curEntry.setState(SmtpCommandEntry.CommandState.REQUEST_IN_PREPARATION); // preparing to send request so setting to correct state
                 sendContinuation(currentCmd, serverResponse);
             } catch (final SmtpAsyncClientException | RuntimeException e) { // when encountering an error on building request from client

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/AuthenticationLoginCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/AuthenticationLoginCommand.java
@@ -25,9 +25,6 @@ public class AuthenticationLoginCommand extends AbstractAuthenticationCommand {
     /** String in place of the actual password in the debugging data. */
     private static final String LOG_PASSWORD_PLACEHOLDER = "<password>";
 
-    /** String literal for "LOGIN". */
-    private static final String LOGIN = "LOGIN";
-
     /** Username for the login (base64 encoded string). */
     private String username;
 

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/DataCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/DataCommand.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import javax.annotation.Nonnull;
+import javax.mail.MessagingException;
+
+import com.sun.mail.smtp.SMTPMessage;
+import com.yahoo.smtpnio.async.response.SmtpResponse;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+/**
+ * This class defines a Data (DATA) command.
+ */
+public class DataCommand extends AbstractSmtpCommand {
+
+    /** String literal for "DATA". */
+    private static final String DATA = "DATA";
+
+    /** The message to be sent. */
+    private SMTPMessage message;
+
+    /**
+     * Initializes a DATA command object that contains the message to be sent.
+     *
+     * @param message a {@link SMTPMessage} containing the message
+     */
+    public DataCommand(@Nonnull final SMTPMessage message) {
+        super(DATA);
+        this.message = message;
+    }
+
+    @Override
+    public ByteBuf getNextCommandLineAfterContinuation(@Nonnull final SmtpResponse serverResponse) {
+        try {
+            final ByteArrayOutputStream output = new ByteArrayOutputStream();
+            message.writeTo(output);
+            return Unpooled.buffer(output.size() + SmtpClientConstants.PADDING_LEN)
+                    .writeBytes(output.toByteArray())
+                    .writeBytes(SmtpClientConstants.CRLF.getBytes(StandardCharsets.US_ASCII))
+                    .writeByte(SmtpClientConstants.PERIOD)
+                    .writeBytes(SmtpClientConstants.CRLF.getBytes(StandardCharsets.US_ASCII));
+        } catch (final MessagingException | IOException e) {
+            return null;
+        }
+    }
+
+    /**
+     * @return the {@link SMTPMessage} object
+     */
+    public SMTPMessage getMessage() {
+        return message;
+    }
+
+    @Override
+    public SmtpCommandType getCommandType() {
+        return SmtpRFCSupportedCommandType.DATA;
+    }
+
+    @Override
+    public void cleanup() {
+        super.cleanup();
+        message = null;
+    }
+}

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/DataCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/DataCommand.java
@@ -6,7 +6,6 @@ package com.yahoo.smtpnio.async.request;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.function.Supplier;
 
 import javax.annotation.Nonnull;
@@ -68,9 +67,9 @@ public class DataCommand extends AbstractSmtpCommand {
         }
         return Unpooled.buffer(bytes.length + SmtpClientConstants.PADDING_LEN)
             .writeBytes(bytes)
-            .writeBytes(SmtpClientConstants.CRLF.getBytes(StandardCharsets.US_ASCII))
+            .writeBytes(AbstractSmtpCommand.CRLF_B)
             .writeByte(SmtpClientConstants.PERIOD)
-            .writeBytes(SmtpClientConstants.CRLF.getBytes(StandardCharsets.US_ASCII));
+            .writeBytes(AbstractSmtpCommand.CRLF_B);
     }
 
     /**

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/DataStreamCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/DataStreamCommand.java
@@ -9,7 +9,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.SequenceInputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.function.Supplier;
 
 import javax.annotation.Nonnull;

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/DataStreamCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/DataStreamCommand.java
@@ -79,7 +79,7 @@ public class DataStreamCommand extends AbstractSmtpCommand {
     }
 
     /**
-     * Trasnsforms an inputStream into a byte array.
+     * Transforms an inputStream into a byte array.
      *
      * Copied from https://commons.apache.org/proper/commons-io/apidocs/org/apache/commons/io/IOUtils.html#toByteArray-java.io.InputStream-
      *
@@ -90,23 +90,15 @@ public class DataStreamCommand extends AbstractSmtpCommand {
     private byte[] toByteArray(final InputStream inputStream) throws IOException {
         // We use a ThresholdingOutputStream to avoid reading AND writing more than Integer.MAX_VALUE.
         try (final ByteArrayOutputStream ubaOutput = new ByteArrayOutputStream()) {
-            copy(inputStream, ubaOutput);
+            byte[] buffer = new byte[1024];
+            long count = 0;
+            int n;
+            while (-1 != (n = inputStream.read(buffer))) {
+                ubaOutput.write(buffer, 0, n);
+                count += n;
+            }
             return ubaOutput.toByteArray();
         }
-    }
-
-    private int copy(final InputStream inputStream, final OutputStream outputStream) throws IOException {
-        return (int) copyLarge(inputStream, outputStream, new byte[1024]);
-    }
-
-    private long copyLarge(final InputStream inputStream, final OutputStream outputStream, final byte[] buffer) throws IOException {
-        long count = 0;
-        int n;
-        while (-1 != (n = inputStream.read(buffer))) {
-            outputStream.write(buffer, 0, n);
-            count += n;
-        }
-        return count;
     }
 
     @Override

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/DataStreamCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/DataStreamCommand.java
@@ -54,6 +54,12 @@ public class DataStreamCommand extends AbstractSmtpCommand {
         return "DATA stream";
     }
 
+    /**
+     * @return the message held in this command.
+     *
+     * For testing purposes only. InputStream is stateful, thus consuming this message will alter the state of
+     * this command.
+     */
     InputStream getMessage() {
         return message;
     }
@@ -72,7 +78,15 @@ public class DataStreamCommand extends AbstractSmtpCommand {
         }
     }
 
-
+    /**
+     * Trasnsforms an inputStream into a byte array.
+     *
+     * Copied from https://commons.apache.org/proper/commons-io/apidocs/org/apache/commons/io/IOUtils.html#toByteArray-java.io.InputStream-
+     *
+     * @param inputStream the InputStream to read.
+     * @return the requested byte array.
+     * @throws IOException - if an I/O error occurs.
+     */
     private byte[] toByteArray(final InputStream inputStream) throws IOException {
         // We use a ThresholdingOutputStream to avoid reading AND writing more than Integer.MAX_VALUE.
         try (final ByteArrayOutputStream ubaOutput = new ByteArrayOutputStream()) {

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/DataStreamCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/DataStreamCommand.java
@@ -28,7 +28,7 @@ import io.netty.handler.stream.ChunkedStream;
 public class DataStreamCommand extends AbstractSmtpCommand {
     /** String literal for "DATA". */
     private static final String DATA = "DATA";
-    private static final byte[] END_OF_INPUT = "\r\n.\r\n".getBytes(StandardCharsets.US_ASCII);
+    private static final byte[] END_OF_INPUT = {'\r', '\n', '.', '\r', '\n'};
 
     /** The message to be sent. */
     private InputStream message;

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/DataStreamCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/DataStreamCommand.java
@@ -4,10 +4,11 @@
  */
 package com.yahoo.smtpnio.async.request;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.SequenceInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.function.Supplier;
 
@@ -96,8 +97,7 @@ public class DataStreamCommand extends AbstractSmtpCommand {
 
     @Override
     public void encodeCommandAfterContinuation(final Channel channel, final Supplier<ChannelPromise> writeFuture, final SmtpResponse response) {
-        channel.write(new ChunkedStream(message), writeFuture.get());
-        channel.writeAndFlush(Unpooled.wrappedBuffer(END_OF_INPUT));
+        channel.write(new ChunkedStream(new SequenceInputStream(message, new ByteArrayInputStream(END_OF_INPUT))), writeFuture.get());
     }
 
     @Override

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/DataStreamCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/DataStreamCommand.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.function.Supplier;
+
+import javax.annotation.Nonnull;
+
+import com.yahoo.smtpnio.async.response.SmtpResponse;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.stream.ChunkedStream;
+
+/**
+ * This class defines a Data (DATA) command.
+ */
+public class DataStreamCommand extends AbstractSmtpCommand {
+    /** String literal for "DATA". */
+    private static final String DATA = "DATA";
+    private static final byte[] END_OF_INPUT = "\r\n.\r\n".getBytes(StandardCharsets.US_ASCII);
+
+    /** The message to be sent. */
+    private InputStream message;
+
+    /**
+     * Initializes a DATA command object that contains the message to be sent.
+     *
+     * @param message a {@link InputStream} representing the message
+     */
+    public DataStreamCommand(@Nonnull final InputStream message) {
+        super(DATA);
+        this.message = message;
+    }
+
+    @Override
+    public boolean isCommandLineDataSensitive() {
+        // prevents logging
+        return true;
+    }
+
+    @Override
+    public String getDebugData() {
+        return "DATA stream";
+    }
+
+    InputStream getMessage() {
+        return message;
+    }
+
+    @Override
+    public ByteBuf getNextCommandLineAfterContinuation(@Nonnull final SmtpResponse serverResponse) {
+        try {
+            final byte[] bytes = toByteArray(message);
+            return Unpooled.buffer(bytes.length + SmtpClientConstants.PADDING_LEN)
+                .writeBytes(bytes)
+                .writeBytes(SmtpClientConstants.CRLF.getBytes(StandardCharsets.US_ASCII))
+                .writeByte(SmtpClientConstants.PERIOD)
+                .writeBytes(SmtpClientConstants.CRLF.getBytes(StandardCharsets.US_ASCII));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    private byte[] toByteArray(final InputStream inputStream) throws IOException {
+        // We use a ThresholdingOutputStream to avoid reading AND writing more than Integer.MAX_VALUE.
+        try (final ByteArrayOutputStream ubaOutput = new ByteArrayOutputStream()) {
+            copy(inputStream, ubaOutput);
+            return ubaOutput.toByteArray();
+        }
+    }
+
+    private int copy(final InputStream inputStream, final OutputStream outputStream) throws IOException {
+        return (int) copyLarge(inputStream, outputStream, new byte[1024]);
+    }
+
+    private long copyLarge(final InputStream inputStream, final OutputStream outputStream, final byte[] buffer) throws IOException {
+        long count = 0;
+        int n;
+        while (-1 != (n = inputStream.read(buffer))) {
+            outputStream.write(buffer, 0, n);
+            count += n;
+        }
+        return count;
+    }
+
+    @Override
+    public void encodeCommandAfterContinuation(final Channel channel, final Supplier<ChannelPromise> writeFuture, final SmtpResponse response) {
+        channel.write(new ChunkedStream(message), writeFuture.get());
+        channel.writeAndFlush(Unpooled.wrappedBuffer(END_OF_INPUT));
+    }
+
+    @Override
+    public SmtpCommandType getCommandType() {
+        return SmtpRFCSupportedCommandType.DATA;
+    }
+
+    @Override
+    public void cleanup() {
+        super.cleanup();
+        try {
+            message.close();
+        } catch (IOException e) {
+            // Do nothing
+        }
+        message = null;
+    }
+}

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/DataStreamCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/DataStreamCommand.java
@@ -64,9 +64,9 @@ public class DataStreamCommand extends AbstractSmtpCommand {
             final byte[] bytes = toByteArray(message);
             return Unpooled.buffer(bytes.length + SmtpClientConstants.PADDING_LEN)
                 .writeBytes(bytes)
-                .writeBytes(SmtpClientConstants.CRLF.getBytes(StandardCharsets.US_ASCII))
+                .writeBytes(AbstractSmtpCommand.CRLF_B)
                 .writeByte(SmtpClientConstants.PERIOD)
-                .writeBytes(SmtpClientConstants.CRLF.getBytes(StandardCharsets.US_ASCII));
+                .writeBytes(AbstractSmtpCommand.CRLF_B);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/ExpandCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/ExpandCommand.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+/**
+ * This class defines an Expand (EXPN) command.
+ */
+public class ExpandCommand extends AbstractSmtpCommand {
+
+    /** String literal for "EXPN". */
+    private static final String EXPN = "EXPN";
+
+    /**
+     * Initializes a EXPN command object used to log out of the server. Note that not all SMTP servers have support for this command.
+     */
+    public ExpandCommand() {
+        super(EXPN);
+    }
+
+    @Override
+    public SmtpCommandType getCommandType() {
+        return SmtpRFCSupportedCommandType.EXPN;
+    }
+}

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/HelpCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/HelpCommand.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+/**
+ * This class defines a Help (HELP) command.
+ */
+public class HelpCommand extends AbstractSmtpCommand {
+
+    /** String literal for "HELP". */
+    private static final String HELP = "HELP";
+
+    /**
+     * Initializes a HELP command object.
+     */
+    public HelpCommand() {
+        super(HELP);
+    }
+
+    @Override
+    public SmtpCommandType getCommandType() {
+        return SmtpRFCSupportedCommandType.HELP;
+    }
+}

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/MailCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/MailCommand.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+/** This class defines a Mail (MAIL) command. */
+public class MailCommand extends AbstractSmtpCommand {
+
+    /** String literal for "MAIL". */
+    private static final String MAIL = "MAIL";
+
+    /** String literal for "FROM". */
+    private static final String FROM = "FROM";
+
+    /** Sender of the message. */
+    private String sender;
+
+    /** Collection of additional mail parameters that can be sent. */
+    @Nullable
+    private Collection<MailParameter> mailParameters;
+
+    /**
+     * A container class that holds values for additional mail parameters. Parameters are keywords associated with
+     * optional values. Refer to RFC 5321 for details.
+     */
+    public static class MailParameter {
+
+        /** Keyword of the parameter. */
+        @Nonnull
+        private final String keyword;
+
+        /** Value of the parameter (optional). */
+        @Nullable
+        private final String value;
+
+        /**
+         * Constructor for a mail parameter with only the keyword.
+         *
+         * @param keyword the keyword
+         */
+        public MailParameter(@Nonnull final String keyword) {
+            this.keyword = keyword;
+            this.value = null;
+        }
+
+        /**
+         * Constructor for a mail parameter with a keyword/value pair.
+         *
+         * @param keyword the keyword
+         * @param value the argument associated with the keyword
+         */
+        public MailParameter(@Nonnull final String keyword, @Nonnull final String value) {
+            this.keyword = keyword;
+            this.value = value;
+        }
+    }
+
+    /**
+     * Initializes a MAIL command without the sender.
+     */
+    public MailCommand() {
+        this("");
+    }
+
+
+    /**
+     * Initializes a MAIL command with a specified sender, but no additional mail parameters.
+     *
+     * @param sender the sender
+     */
+    public MailCommand(@Nonnull final String sender) {
+        this(sender, null);
+    }
+
+
+    /**
+     * Initializes a MAIL command with a specified collection of additional mail parameters, but no sender.
+     *
+     * @param mailParameters collection of mail parameters to be sent
+     */
+    public MailCommand(@Nonnull final Collection<MailParameter> mailParameters) {
+        this("", mailParameters);
+    }
+
+
+    /**
+     * Initializes a MAIL command with a specified sender and a collection additional mail parameters.
+     *
+     * @param sender the sender
+     * @param mailParameters collection of mail parameters to be sent
+     */
+    public MailCommand(@Nonnull final String sender, @Nullable final Collection<MailParameter> mailParameters) {
+        super(MAIL);
+        this.sender = sender;
+        this.mailParameters = mailParameters;
+    }
+
+    @Nonnull
+    @Override
+    public ByteBuf getCommandLineBytes() {
+        // space, colon, left and right angle brackets make up 4 of extra chars; padding is added to account for possible additional arguments
+        final int len = command.length() + FROM.length() + sender.length() + CRLF_B.length + SmtpClientConstants.PADDING_LEN;
+        final ByteBuf res = Unpooled.buffer(len)
+                .writeBytes(command.getBytes(StandardCharsets.US_ASCII))
+                .writeByte(SmtpClientConstants.SPACE)
+                .writeBytes(FROM.getBytes(StandardCharsets.US_ASCII))
+                .writeByte(SmtpClientConstants.COLON)
+                .writeByte(SmtpClientConstants.L_ANGLE_BRACKET)
+                .writeBytes(sender.getBytes(StandardCharsets.US_ASCII))
+                .writeByte(SmtpClientConstants.R_ANGLE_BRACKET);
+
+        if (mailParameters != null) { // adds the additional mail parameters if available
+            for (final MailParameter mailParameter : mailParameters) {
+                res.writeByte(SmtpClientConstants.SPACE)
+                        .writeBytes(mailParameter.keyword.getBytes(StandardCharsets.US_ASCII));
+                if (mailParameter.value != null) {
+                    res.writeByte(SmtpClientConstants.EQUAL)
+                            .writeBytes(mailParameter.value.getBytes(StandardCharsets.US_ASCII));
+                }
+            }
+        }
+        return res.writeBytes(CRLF_B);
+    }
+
+    @Override
+    public SmtpCommandType getCommandType() {
+        return SmtpRFCSupportedCommandType.MAIL;
+    }
+
+    @Override
+    public void cleanup() {
+        super.cleanup();
+        sender = null;
+        mailParameters = null;
+    }
+}

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/NoopCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/NoopCommand.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+/**
+ * This class defines a Noop (NOOP) command.
+ */
+public class NoopCommand extends AbstractSmtpCommand {
+
+    /** String literal for "NOOP". */
+    private static final String NOOP = "NOOP";
+
+    /**
+     * Initializes a NOOP command object.
+     */
+    public NoopCommand() {
+        super(NOOP);
+    }
+
+    @Override
+    public SmtpCommandType getCommandType() {
+        return SmtpRFCSupportedCommandType.NOOP;
+    }
+}

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/RecipientCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/RecipientCommand.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+import java.nio.charset.StandardCharsets;
+
+import javax.annotation.Nonnull;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+/**
+ * This class defines a Recipient (RCPT) command.
+ */
+public class RecipientCommand extends AbstractSmtpCommand {
+
+    /** String literal for "RCPT". */
+    private static final String RCPT = "RCPT";
+
+    /** String literal for "TO". */
+    private static final String TO = "TO";
+
+    /** The recipient argument for the command. */
+    private String recipient;
+
+    /**
+     * Initializes a RCPT command object.
+     *
+     * @param recipient the address of the recipient.
+     */
+    public RecipientCommand(@Nonnull final String recipient) {
+        super(RCPT);
+        this.recipient = recipient;
+    }
+
+    @Nonnull
+    @Override
+    public ByteBuf getCommandLineBytes() {
+        // space, colon, left and right angle brackets make up 4 of the extra chars
+        final int len = command.length() + TO.length() + recipient.length() + CRLF_B.length + SmtpClientConstants.PADDING_LEN;
+        return Unpooled.buffer(len)
+                .writeBytes(command.getBytes(StandardCharsets.US_ASCII))
+                .writeByte(SmtpClientConstants.SPACE)
+                .writeBytes(TO.getBytes(StandardCharsets.US_ASCII))
+                .writeByte(SmtpClientConstants.COLON)
+                .writeByte(SmtpClientConstants.L_ANGLE_BRACKET)
+                .writeBytes(recipient.getBytes(StandardCharsets.US_ASCII))
+                .writeByte(SmtpClientConstants.R_ANGLE_BRACKET)
+                .writeBytes(CRLF_B);
+    }
+
+    @Override
+    public SmtpCommandType getCommandType() {
+        return SmtpRFCSupportedCommandType.RCPT;
+    }
+
+    @Override
+    public void cleanup() {
+        super.cleanup();
+        recipient = null;
+    }
+}

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/ResetCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/ResetCommand.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+/**
+ * This class defines a Reset (RSET) command.
+ */
+public class ResetCommand extends AbstractSmtpCommand {
+
+    /** String literal for "RSET". */
+    private static final String RSET = "RSET";
+
+    /**
+     * Initializes a RSET command object.
+     */
+    public ResetCommand() {
+        super(RSET);
+    }
+
+    @Override
+    public SmtpCommandType getCommandType() {
+        return SmtpRFCSupportedCommandType.RSET;
+    }
+}

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/SmtpClientConstants.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/SmtpClientConstants.java
@@ -25,6 +25,21 @@ final class SmtpClientConstants {
     /** Start of Header char (aka. CTRL-A or \001). **/
     static final char SOH = 0x1;
 
+    /** Period character. */
+    static final char PERIOD = '.';
+
+    /** Equal character. */
+    static final char EQUAL = '=';
+
+    /** Left angle bracket. */
+    static final char L_ANGLE_BRACKET = '<';
+
+    /** Right angle bracket. */
+    static final char R_ANGLE_BRACKET = '>';
+
+    /** Literal for colon. */
+    static final char COLON = ':';
+
     /** Private constructor to avoid constructing instance of this class. */
     private SmtpClientConstants() {
     }

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/SmtpRFCSupportedCommandType.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/SmtpRFCSupportedCommandType.java
@@ -21,6 +21,30 @@ enum SmtpRFCSupportedCommandType implements SmtpCommandType {
     /** The Authentication command (AUTH). */
     AUTH,
 
+    /** The Mail command (MAIL). */
+    MAIL,
+
+    /** The Recipient command (RCPT). */
+    RCPT,
+
+    /** The Data command (DATA). */
+    DATA,
+
+    /** The Reset command (RSET). */
+    RSET,
+
+    /** The Noop command (NOOP). */
+    NOOP,
+
+    /** The Verify command (VRFY). */
+    VRFY,
+
+    /** The Help command (HELP). */
+    HELP,
+
+    /** The Expand command (EXPN). */
+    EXPN,
+
     /** The Starttls command (Starttls). */
     STARTTLS;
 

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/SmtpRequest.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/SmtpRequest.java
@@ -4,6 +4,8 @@
  */
 package com.yahoo.smtpnio.async.request;
 
+import java.util.function.Supplier;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -11,6 +13,8 @@ import com.yahoo.smtpnio.async.exception.SmtpAsyncClientException;
 import com.yahoo.smtpnio.async.response.SmtpResponse;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelPromise;
 
 /**
  * This interface defines a SMTP command sent from the client.
@@ -52,6 +56,20 @@ public interface SmtpRequest {
      */
     @Nullable
     ByteBuf getNextCommandLineAfterContinuation(SmtpResponse serverResponse) throws SmtpAsyncClientException;
+
+    /**
+     * Encodes the command line over wire.
+     *
+     * @param channel the channel connected to the server
+     * @param writeFuture the supplier to propagate write errors
+     * @param serverResponse response received from the server
+     *
+     * @throws SmtpAsyncClientException when encountering an error encoding the input
+     */
+    default void encodeCommandAfterContinuation(final Channel channel, final Supplier<ChannelPromise> writeFuture,
+                                                final SmtpResponse serverResponse) throws SmtpAsyncClientException {
+        channel.writeAndFlush(this.getNextCommandLineAfterContinuation(serverResponse), writeFuture.get());
+    }
 
     /**
      * Avoids loitering.

--- a/core/src/main/java/com/yahoo/smtpnio/async/request/VerifyCommand.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/request/VerifyCommand.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+/**
+ * This class defines a Verify (VRFY) command.
+ */
+public class VerifyCommand extends AbstractSmtpCommand {
+
+    /** String literal for "VRFY". */
+    private static final String VRFY = "VRFY";
+
+    /**
+     * Initializes a VRFY command object.
+     */
+    public VerifyCommand() {
+        super(VRFY);
+    }
+
+    @Override
+    public SmtpCommandType getCommandType() {
+        return SmtpRFCSupportedCommandType.VRFY;
+    }
+}

--- a/core/src/test/java/com/yahoo/smtpnio/async/client/SmtpAsyncClientTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/client/SmtpAsyncClientTest.java
@@ -41,6 +41,7 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.string.StringDecoder;
 import io.netty.handler.codec.string.StringEncoder;
 import io.netty.handler.ssl.SslHandler;
+import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.concurrent.GenericFutureListener;
 
@@ -132,14 +133,15 @@ public class SmtpAsyncClientTest {
 
         // verify initChannel
         final ArgumentCaptor<ChannelHandler> handlerCaptor = ArgumentCaptor.forClass(ChannelHandler.class);
-        Mockito.verify(socketPipeline, Mockito.times(5)).addLast(Mockito.anyString(), handlerCaptor.capture());
-        Assert.assertEquals(handlerCaptor.getAllValues().size(), 5, "Unexpected count of ChannelHandler added.");
+        Mockito.verify(socketPipeline, Mockito.times(6)).addLast(Mockito.anyString(), handlerCaptor.capture());
+        Assert.assertEquals(handlerCaptor.getAllValues().size(), 6, "Unexpected count of ChannelHandler added.");
         // following order should be preserved
         Assert.assertEquals(handlerCaptor.getAllValues().get(0).getClass(), IdleStateHandler.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(1).getClass(), SmtpClientRespReader.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(2).getClass(), StringDecoder.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(3).getClass(), StringEncoder.class, "expected class mismatched.");
-        Assert.assertEquals(handlerCaptor.getAllValues().get(4).getClass(), SmtpClientRespDecoder.class, "expected class mismatched.");
+        Assert.assertEquals(handlerCaptor.getAllValues().get(4).getClass(), ChunkedWriteHandler.class, "expected class missmatched.");
+        Assert.assertEquals(handlerCaptor.getAllValues().get(5).getClass(), SmtpClientRespDecoder.class, "expected class mismatched.");
 
         // verify GenericFutureListener.operationComplete()
         final GenericFutureListener listener = listenerCaptor.getAllValues().get(0);
@@ -155,9 +157,10 @@ public class SmtpAsyncClientTest {
         Assert.assertEquals(handlerCaptorAfter.getAllValues().get(0).getClass(), SslDetectHandler.class, "expected class mismatched.");
 
         final ArgumentCaptor<ChannelHandler> handlerCaptorLast = ArgumentCaptor.forClass(ChannelHandler.class);
-        Mockito.verify(nettyPipeline, Mockito.times(1)).addLast(Mockito.anyString(), handlerCaptorLast.capture());
-        Assert.assertEquals(handlerCaptorLast.getAllValues().size(), 1, "Unexpected count of ChannelHandler added.");
-        Assert.assertEquals(handlerCaptorLast.getAllValues().get(0).getClass(), SmtpClientConnectHandler.class, "expected class mismatched.");
+        Mockito.verify(nettyPipeline, Mockito.times(2)).addLast(Mockito.anyString(), handlerCaptorLast.capture());
+        Assert.assertEquals(handlerCaptorLast.getAllValues().size(), 2, "Unexpected count of ChannelHandler added.");
+        Assert.assertEquals(handlerCaptorLast.getAllValues().get(0).getClass(), ChunkedWriteHandler.class, "expected class mismatched.");
+        Assert.assertEquals(handlerCaptorLast.getAllValues().get(1).getClass(), SmtpClientConnectHandler.class, "expected class mismatched.");
         // verify if session level is on, whether debug call will be called
         // verify logging messages
         Mockito.verify(logger, Mockito.times(1)).debug(
@@ -221,14 +224,15 @@ public class SmtpAsyncClientTest {
 
         // verify initChannel
         final ArgumentCaptor<ChannelHandler> handlerCaptor = ArgumentCaptor.forClass(ChannelHandler.class);
-        Mockito.verify(socketPipeline, Mockito.times(5)).addLast(Mockito.anyString(), handlerCaptor.capture());
-        Assert.assertEquals(handlerCaptor.getAllValues().size(), 5, "Unexpected count of ChannelHandler added.");
+        Mockito.verify(socketPipeline, Mockito.times(6)).addLast(Mockito.anyString(), handlerCaptor.capture());
+        Assert.assertEquals(handlerCaptor.getAllValues().size(), 6, "Unexpected count of ChannelHandler added.");
         // following order should be preserved
         Assert.assertEquals(handlerCaptor.getAllValues().get(0).getClass(), IdleStateHandler.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(1).getClass(), SmtpClientRespReader.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(2).getClass(), StringDecoder.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(3).getClass(), StringEncoder.class, "expected class mismatched.");
-        Assert.assertEquals(handlerCaptor.getAllValues().get(4).getClass(), SmtpClientRespDecoder.class, "expected class mismatched.");
+        Assert.assertEquals(handlerCaptor.getAllValues().get(4).getClass(), ChunkedWriteHandler.class, "expected class missmatched.");
+        Assert.assertEquals(handlerCaptor.getAllValues().get(5).getClass(), SmtpClientRespDecoder.class, "expected class mismatched.");
 
         // verify GenericFutureListener.operationComplete()
         final GenericFutureListener listener = listenerCaptor.getAllValues().get(0);
@@ -303,14 +307,15 @@ public class SmtpAsyncClientTest {
 
         // verify initChannel
         final ArgumentCaptor<ChannelHandler> handlerCaptor = ArgumentCaptor.forClass(ChannelHandler.class);
-        Mockito.verify(socketPipeline, Mockito.times(5)).addLast(Mockito.anyString(), handlerCaptor.capture());
-        Assert.assertEquals(handlerCaptor.getAllValues().size(), 5, "Unexpected count of ChannelHandler added.");
+        Mockito.verify(socketPipeline, Mockito.times(6)).addLast(Mockito.anyString(), handlerCaptor.capture());
+        Assert.assertEquals(handlerCaptor.getAllValues().size(), 6, "Unexpected count of ChannelHandler added.");
         // following order should be preserved
         Assert.assertEquals(handlerCaptor.getAllValues().get(0).getClass(), IdleStateHandler.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(1).getClass(), SmtpClientRespReader.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(2).getClass(), StringDecoder.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(3).getClass(), StringEncoder.class, "expected class mismatched.");
-        Assert.assertEquals(handlerCaptor.getAllValues().get(4).getClass(), SmtpClientRespDecoder.class, "expected class mismatched.");
+        Assert.assertEquals(handlerCaptor.getAllValues().get(4).getClass(), ChunkedWriteHandler.class, "expected class missmatched.");
+        Assert.assertEquals(handlerCaptor.getAllValues().get(5).getClass(), SmtpClientRespDecoder.class, "expected class mismatched.");
 
         // verify GenericFutureListener.operationComplete()
         final GenericFutureListener listener = listenerCaptor.getAllValues().get(0);
@@ -385,14 +390,15 @@ public class SmtpAsyncClientTest {
 
         // verify initChannel
         final ArgumentCaptor<ChannelHandler> handlerCaptor = ArgumentCaptor.forClass(ChannelHandler.class);
-        Mockito.verify(socketPipeline, Mockito.times(5)).addLast(Mockito.anyString(), handlerCaptor.capture());
-        Assert.assertEquals(handlerCaptor.getAllValues().size(), 5, "Unexpected count of ChannelHandler added.");
+        Mockito.verify(socketPipeline, Mockito.times(6)).addLast(Mockito.anyString(), handlerCaptor.capture());
+        Assert.assertEquals(handlerCaptor.getAllValues().size(), 6, "Unexpected count of ChannelHandler added.");
         // following order should be preserved
         Assert.assertEquals(handlerCaptor.getAllValues().get(0).getClass(), IdleStateHandler.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(1).getClass(), SmtpClientRespReader.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(2).getClass(), StringDecoder.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(3).getClass(), StringEncoder.class, "expected class mismatched.");
-        Assert.assertEquals(handlerCaptor.getAllValues().get(4).getClass(), SmtpClientRespDecoder.class, "expected class mismatched.");
+        Assert.assertEquals(handlerCaptor.getAllValues().get(4).getClass(), ChunkedWriteHandler.class, "expected class missmatched.");
+        Assert.assertEquals(handlerCaptor.getAllValues().get(5).getClass(), SmtpClientRespDecoder.class, "expected class mismatched.");
 
         // verify GenericFutureListener.operationComplete()
         final GenericFutureListener listener = listenerCaptor.getAllValues().get(0);
@@ -469,14 +475,15 @@ public class SmtpAsyncClientTest {
 
         // verify initChannel
         final ArgumentCaptor<ChannelHandler> handlerCaptor = ArgumentCaptor.forClass(ChannelHandler.class);
-        Mockito.verify(socketPipeline, Mockito.times(5)).addLast(Mockito.anyString(), handlerCaptor.capture());
-        Assert.assertEquals(handlerCaptor.getAllValues().size(), 5, "Unexpected count of ChannelHandler added.");
+        Mockito.verify(socketPipeline, Mockito.times(6)).addLast(Mockito.anyString(), handlerCaptor.capture());
+        Assert.assertEquals(handlerCaptor.getAllValues().size(), 6, "Unexpected count of ChannelHandler added.");
         // following order should be preserved
         Assert.assertEquals(handlerCaptor.getAllValues().get(0).getClass(), IdleStateHandler.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(1).getClass(), SmtpClientRespReader.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(2).getClass(), StringDecoder.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(3).getClass(), StringEncoder.class, "expected class mismatched.");
-        Assert.assertEquals(handlerCaptor.getAllValues().get(4).getClass(), SmtpClientRespDecoder.class, "expected class mismatched.");
+        Assert.assertEquals(handlerCaptor.getAllValues().get(4).getClass(), ChunkedWriteHandler.class, "expected class missmatched.");
+        Assert.assertEquals(handlerCaptor.getAllValues().get(5).getClass(), SmtpClientRespDecoder.class, "expected class mismatched.");
 
         // verify GenericFutureListener.operationComplete()
         final GenericFutureListener listener = listenerCaptor.getAllValues().get(0);
@@ -492,9 +499,10 @@ public class SmtpAsyncClientTest {
         Assert.assertEquals(handlerCaptorAfter.getAllValues().get(0).getClass(), SslDetectHandler.class, "expected class mismatched.");
 
         final ArgumentCaptor<ChannelHandler> handlerCaptorLast = ArgumentCaptor.forClass(ChannelHandler.class);
-        Mockito.verify(nettyPipeline, Mockito.times(1)).addLast(Mockito.anyString(), handlerCaptorLast.capture());
-        Assert.assertEquals(handlerCaptorLast.getAllValues().size(), 1, "Unexpected count of ChannelHandler added.");
-        Assert.assertEquals(handlerCaptorLast.getAllValues().get(0).getClass(), SmtpClientConnectHandler.class, "expected class mismatched.");
+        Mockito.verify(nettyPipeline, Mockito.times(2)).addLast(Mockito.anyString(), handlerCaptorLast.capture());
+        Assert.assertEquals(handlerCaptorLast.getAllValues().size(), 2, "Unexpected count of ChannelHandler added.");
+        Assert.assertEquals(handlerCaptorLast.getAllValues().get(0).getClass(), ChunkedWriteHandler.class, "expected class mismatched.");
+        Assert.assertEquals(handlerCaptorLast.getAllValues().get(1).getClass(), SmtpClientConnectHandler.class, "expected class mismatched.");
         // verify if session level is on, whether debug call will be called
         // verify logging messages
         Mockito.verify(logger, Mockito.times(1)).debug(
@@ -558,14 +566,15 @@ public class SmtpAsyncClientTest {
 
         // verify initChannel
         final ArgumentCaptor<ChannelHandler> handlerCaptor = ArgumentCaptor.forClass(ChannelHandler.class);
-        Mockito.verify(socketPipeline, Mockito.times(5)).addLast(Mockito.anyString(), handlerCaptor.capture());
-        Assert.assertEquals(handlerCaptor.getAllValues().size(), 5, "Unexpected count of ChannelHandler added.");
+        Mockito.verify(socketPipeline, Mockito.times(6)).addLast(Mockito.anyString(), handlerCaptor.capture());
+        Assert.assertEquals(handlerCaptor.getAllValues().size(), 6, "Unexpected count of ChannelHandler added.");
         // following order should be preserved
         Assert.assertEquals(handlerCaptor.getAllValues().get(0).getClass(), IdleStateHandler.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(1).getClass(), SmtpClientRespReader.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(2).getClass(), StringDecoder.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(3).getClass(), StringEncoder.class, "expected class mismatched.");
-        Assert.assertEquals(handlerCaptor.getAllValues().get(4).getClass(), SmtpClientRespDecoder.class, "expected class mismatched.");
+        Assert.assertEquals(handlerCaptor.getAllValues().get(4).getClass(), ChunkedWriteHandler.class, "expected class missmatched.");
+        Assert.assertEquals(handlerCaptor.getAllValues().get(5).getClass(), SmtpClientRespDecoder.class, "expected class mismatched.");
 
         // verify GenericFutureListener.operationComplete()
         final GenericFutureListener listener = listenerCaptor.getAllValues().get(0);
@@ -581,9 +590,10 @@ public class SmtpAsyncClientTest {
         Assert.assertEquals(handlerCaptorAfter.getAllValues().get(0).getClass(), SslDetectHandler.class, "expected class mismatched.");
 
         final ArgumentCaptor<ChannelHandler> handlerCaptorLast = ArgumentCaptor.forClass(ChannelHandler.class);
-        Mockito.verify(nettyPipeline, Mockito.times(1)).addLast(Mockito.anyString(), handlerCaptorLast.capture());
-        Assert.assertEquals(handlerCaptorLast.getAllValues().size(), 1, "Unexpected count of ChannelHandler added.");
-        Assert.assertEquals(handlerCaptorLast.getAllValues().get(0).getClass(), SmtpClientConnectHandler.class, "expected class mismatched.");
+        Mockito.verify(nettyPipeline, Mockito.times(2)).addLast(Mockito.anyString(), handlerCaptorLast.capture());
+        Assert.assertEquals(handlerCaptorLast.getAllValues().size(), 2, "Unexpected count of ChannelHandler added.");
+        Assert.assertEquals(handlerCaptorLast.getAllValues().get(1).getClass(), SmtpClientConnectHandler.class, "expected class mismatched.");
+        Assert.assertEquals(handlerCaptorLast.getAllValues().get(0).getClass(), ChunkedWriteHandler.class, "expected class mismatched.");
 
         // verify to make sure logger isn't called
         Mockito.verify(logger, Mockito.times(0)).debug(Mockito.anyString(), Mockito.anyLong(), Mockito.anyString(), Mockito.anyString(),
@@ -643,14 +653,15 @@ public class SmtpAsyncClientTest {
 
         // verify initChannel
         final ArgumentCaptor<ChannelHandler> handlerCaptor = ArgumentCaptor.forClass(ChannelHandler.class);
-        Mockito.verify(socketPipeline, Mockito.times(5)).addLast(Mockito.anyString(), handlerCaptor.capture());
-        Assert.assertEquals(handlerCaptor.getAllValues().size(), 5, "Unexpected count of ChannelHandler added.");
+        Mockito.verify(socketPipeline, Mockito.times(6)).addLast(Mockito.anyString(), handlerCaptor.capture());
+        Assert.assertEquals(handlerCaptor.getAllValues().size(), 6, "Unexpected count of ChannelHandler added.");
         // following order should be preserved
         Assert.assertEquals(handlerCaptor.getAllValues().get(0).getClass(), IdleStateHandler.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(1).getClass(), SmtpClientRespReader.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(2).getClass(), StringDecoder.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(3).getClass(), StringEncoder.class, "expected class mismatched.");
-        Assert.assertEquals(handlerCaptor.getAllValues().get(4).getClass(), SmtpClientRespDecoder.class, "expected class mismatched.");
+        Assert.assertEquals(handlerCaptor.getAllValues().get(4).getClass(), ChunkedWriteHandler.class, "expected class missmatched.");
+        Assert.assertEquals(handlerCaptor.getAllValues().get(5).getClass(), SmtpClientRespDecoder.class, "expected class mismatched.");
 
         // verify GenericFutureListener.operationComplete()
         final GenericFutureListener listener = listenerCaptor.getAllValues().get(0);
@@ -721,14 +732,15 @@ public class SmtpAsyncClientTest {
 
         // verify initChannel
         final ArgumentCaptor<ChannelHandler> handlerCaptor = ArgumentCaptor.forClass(ChannelHandler.class);
-        Mockito.verify(socketPipeline, Mockito.times(5)).addLast(Mockito.anyString(), handlerCaptor.capture());
-        Assert.assertEquals(handlerCaptor.getAllValues().size(), 5, "Unexpected count of ChannelHandler added.");
+        Mockito.verify(socketPipeline, Mockito.times(6)).addLast(Mockito.anyString(), handlerCaptor.capture());
+        Assert.assertEquals(handlerCaptor.getAllValues().size(), 6, "Unexpected count of ChannelHandler added.");
         // following order should be preserved
         Assert.assertEquals(handlerCaptor.getAllValues().get(0).getClass(), IdleStateHandler.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(1).getClass(), SmtpClientRespReader.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(2).getClass(), StringDecoder.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(3).getClass(), StringEncoder.class, "expected class mismatched.");
-        Assert.assertEquals(handlerCaptor.getAllValues().get(4).getClass(), SmtpClientRespDecoder.class, "expected class mismatched.");
+        Assert.assertEquals(handlerCaptor.getAllValues().get(4).getClass(), ChunkedWriteHandler.class, "expected class missmatched.");
+        Assert.assertEquals(handlerCaptor.getAllValues().get(5).getClass(), SmtpClientRespDecoder.class, "expected class mismatched.");
 
         // verify GenericFutureListener.operationComplete()
         final GenericFutureListener listener = listenerCaptor.getAllValues().get(0);
@@ -801,14 +813,15 @@ public class SmtpAsyncClientTest {
 
         // verify initChannel
         final ArgumentCaptor<ChannelHandler> handlerCaptor = ArgumentCaptor.forClass(ChannelHandler.class);
-        Mockito.verify(socketPipeline, Mockito.times(5)).addLast(Mockito.anyString(), handlerCaptor.capture());
-        Assert.assertEquals(handlerCaptor.getAllValues().size(), 5, "Unexpected count of ChannelHandler added.");
+        Mockito.verify(socketPipeline, Mockito.times(6)).addLast(Mockito.anyString(), handlerCaptor.capture());
+        Assert.assertEquals(handlerCaptor.getAllValues().size(), 6, "Unexpected count of ChannelHandler added.");
         // following order should be preserved
         Assert.assertEquals(handlerCaptor.getAllValues().get(0).getClass(), IdleStateHandler.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(1).getClass(), SmtpClientRespReader.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(2).getClass(), StringDecoder.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(3).getClass(), StringEncoder.class, "expected class mismatched.");
-        Assert.assertEquals(handlerCaptor.getAllValues().get(4).getClass(), SmtpClientRespDecoder.class, "expected class mismatched.");
+        Assert.assertEquals(handlerCaptor.getAllValues().get(4).getClass(), ChunkedWriteHandler.class, "expected class missmatched.");
+        Assert.assertEquals(handlerCaptor.getAllValues().get(5).getClass(), SmtpClientRespDecoder.class, "expected class mismatched.");
 
         // verify GenericFutureListener.operationComplete()
         final GenericFutureListener listener = listenerCaptor.getAllValues().get(0);
@@ -880,14 +893,15 @@ public class SmtpAsyncClientTest {
 
         // verify initChannel
         final ArgumentCaptor<ChannelHandler> handlerCaptor = ArgumentCaptor.forClass(ChannelHandler.class);
-        Mockito.verify(socketPipeline, Mockito.times(5)).addLast(Mockito.anyString(), handlerCaptor.capture());
-        Assert.assertEquals(handlerCaptor.getAllValues().size(), 5, "Unexpected count of ChannelHandler added.");
+        Mockito.verify(socketPipeline, Mockito.times(6)).addLast(Mockito.anyString(), handlerCaptor.capture());
+        Assert.assertEquals(handlerCaptor.getAllValues().size(), 6, "Unexpected count of ChannelHandler added.");
         // following order should be preserved
         Assert.assertEquals(handlerCaptor.getAllValues().get(0).getClass(), IdleStateHandler.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(1).getClass(), SmtpClientRespReader.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(2).getClass(), StringDecoder.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(3).getClass(), StringEncoder.class, "expected class mismatched.");
-        Assert.assertEquals(handlerCaptor.getAllValues().get(4).getClass(), SmtpClientRespDecoder.class, "expected class mismatched.");
+        Assert.assertEquals(handlerCaptor.getAllValues().get(4).getClass(), ChunkedWriteHandler.class, "expected class missmatched.");
+        Assert.assertEquals(handlerCaptor.getAllValues().get(5).getClass(), SmtpClientRespDecoder.class, "expected class mismatched.");
 
         // verify GenericFutureListener.operationComplete()
         final GenericFutureListener listener = listenerCaptor.getAllValues().get(0);
@@ -969,14 +983,15 @@ public class SmtpAsyncClientTest {
 
         // verify initChannel
         final ArgumentCaptor<ChannelHandler> handlerCaptor = ArgumentCaptor.forClass(ChannelHandler.class);
-        Mockito.verify(socketPipeline, Mockito.times(5)).addLast(Mockito.anyString(), handlerCaptor.capture());
-        Assert.assertEquals(handlerCaptor.getAllValues().size(), 5, "Unexpected count of ChannelHandler added.");
+        Mockito.verify(socketPipeline, Mockito.times(6)).addLast(Mockito.anyString(), handlerCaptor.capture());
+        Assert.assertEquals(handlerCaptor.getAllValues().size(), 6, "Unexpected count of ChannelHandler added.");
         // following order should be preserved
         Assert.assertEquals(handlerCaptor.getAllValues().get(0).getClass(), IdleStateHandler.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(1).getClass(), SmtpClientRespReader.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(2).getClass(), StringDecoder.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(3).getClass(), StringEncoder.class, "expected class mismatched.");
-        Assert.assertEquals(handlerCaptor.getAllValues().get(4).getClass(), SmtpClientRespDecoder.class, "expected class mismatched.");
+        Assert.assertEquals(handlerCaptor.getAllValues().get(4).getClass(), ChunkedWriteHandler.class, "expected class missmatched.");
+        Assert.assertEquals(handlerCaptor.getAllValues().get(5).getClass(), SmtpClientRespDecoder.class, "expected class mismatched.");
 
         // verify GenericFutureListener.operationComplete()
         final GenericFutureListener listener = listenerCaptor.getAllValues().get(0);
@@ -992,9 +1007,10 @@ public class SmtpAsyncClientTest {
         Assert.assertEquals(handlerCaptorAfter.getAllValues().get(0).getClass(), SslDetectHandler.class, "expected class mismatched.");
 
         final ArgumentCaptor<ChannelHandler> handlerCaptorLast = ArgumentCaptor.forClass(ChannelHandler.class);
-        Mockito.verify(nettyPipeline, Mockito.times(1)).addLast(Mockito.anyString(), handlerCaptorLast.capture());
-        Assert.assertEquals(handlerCaptorLast.getAllValues().size(), 1, "Unexpected count of ChannelHandler added.");
-        Assert.assertEquals(handlerCaptorLast.getAllValues().get(0).getClass(), SmtpClientConnectHandler.class, "expected class mismatched.");
+        Mockito.verify(nettyPipeline, Mockito.times(2)).addLast(Mockito.anyString(), handlerCaptorLast.capture());
+        Assert.assertEquals(handlerCaptorLast.getAllValues().size(), 2, "Unexpected count of ChannelHandler added.");
+        Assert.assertEquals(handlerCaptorLast.getAllValues().get(0).getClass(), ChunkedWriteHandler.class, "expected class mismatched.");
+        Assert.assertEquals(handlerCaptorLast.getAllValues().get(1).getClass(), SmtpClientConnectHandler.class, "expected class mismatched.");
         // verify if session level is on, whether debug call will be called
         // verify logging messages
         Mockito.verify(logger, Mockito.times(1)).debug(
@@ -1153,14 +1169,15 @@ public class SmtpAsyncClientTest {
 
         // verify initChannel
         final ArgumentCaptor<ChannelHandler> handlerCaptor = ArgumentCaptor.forClass(ChannelHandler.class);
-        Mockito.verify(socketPipeline, Mockito.times(5)).addLast(Mockito.anyString(), handlerCaptor.capture());
-        Assert.assertEquals(handlerCaptor.getAllValues().size(), 5, "Unexpected count of ChannelHandler added.");
+        Mockito.verify(socketPipeline, Mockito.times(6)).addLast(Mockito.anyString(), handlerCaptor.capture());
+        Assert.assertEquals(handlerCaptor.getAllValues().size(), 6, "Unexpected count of ChannelHandler added.");
         // following order should be preserved
         Assert.assertEquals(handlerCaptor.getAllValues().get(0).getClass(), IdleStateHandler.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(1).getClass(), SmtpClientRespReader.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(2).getClass(), StringDecoder.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(3).getClass(), StringEncoder.class, "expected class mismatched.");
-        Assert.assertEquals(handlerCaptor.getAllValues().get(4).getClass(), SmtpClientRespDecoder.class, "expected class mismatched.");
+        Assert.assertEquals(handlerCaptor.getAllValues().get(4).getClass(), ChunkedWriteHandler.class, "expected class missmatched.");
+        Assert.assertEquals(handlerCaptor.getAllValues().get(5).getClass(), SmtpClientRespDecoder.class, "expected class mismatched.");
 
         // verify GenericFutureListener.operationComplete()
         final GenericFutureListener listener = listenerCaptor.getAllValues().get(0);
@@ -1176,9 +1193,10 @@ public class SmtpAsyncClientTest {
         Assert.assertEquals(handlerCaptorAfter.getAllValues().get(0).getClass(), SslDetectHandler.class, "expected class mismatched.");
 
         final ArgumentCaptor<ChannelHandler> handlerCaptorLast = ArgumentCaptor.forClass(ChannelHandler.class);
-        Mockito.verify(nettyPipeline, Mockito.times(1)).addLast(Mockito.anyString(), handlerCaptorLast.capture());
-        Assert.assertEquals(handlerCaptorLast.getAllValues().size(), 1, "Unexpected count of ChannelHandler added.");
-        Assert.assertEquals(handlerCaptorLast.getAllValues().get(0).getClass(), SmtpClientConnectHandler.class, "expected class mismatched.");
+        Mockito.verify(nettyPipeline, Mockito.times(2)).addLast(Mockito.anyString(), handlerCaptorLast.capture());
+        Assert.assertEquals(handlerCaptorLast.getAllValues().size(), 2, "Unexpected count of ChannelHandler added.");
+        Assert.assertEquals(handlerCaptorLast.getAllValues().get(1).getClass(), SmtpClientConnectHandler.class, "expected class mismatched.");
+        Assert.assertEquals(handlerCaptorLast.getAllValues().get(0).getClass(), ChunkedWriteHandler.class, "expected class mismatched.");
 
         // verify logging messages
         Mockito.verify(logger, Mockito.times(1)).debug(
@@ -1247,14 +1265,15 @@ public class SmtpAsyncClientTest {
 
         // verify initChannel
         final ArgumentCaptor<ChannelHandler> handlerCaptor = ArgumentCaptor.forClass(ChannelHandler.class);
-        Mockito.verify(socketPipeline, Mockito.times(5)).addLast(Mockito.anyString(), handlerCaptor.capture());
-        Assert.assertEquals(handlerCaptor.getAllValues().size(), 5, "Unexpected count of ChannelHandler added.");
+        Mockito.verify(socketPipeline, Mockito.times(6)).addLast(Mockito.anyString(), handlerCaptor.capture());
+        Assert.assertEquals(handlerCaptor.getAllValues().size(), 6, "Unexpected count of ChannelHandler added.");
         // following order should be preserved
         Assert.assertEquals(handlerCaptor.getAllValues().get(0).getClass(), IdleStateHandler.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(1).getClass(), SmtpClientRespReader.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(2).getClass(), StringDecoder.class, "expected class mismatched.");
         Assert.assertEquals(handlerCaptor.getAllValues().get(3).getClass(), StringEncoder.class, "expected class mismatched.");
-        Assert.assertEquals(handlerCaptor.getAllValues().get(4).getClass(), SmtpClientRespDecoder.class, "expected class mismatched.");
+        Assert.assertEquals(handlerCaptor.getAllValues().get(4).getClass(), ChunkedWriteHandler.class, "expected class missmatched.");
+        Assert.assertEquals(handlerCaptor.getAllValues().get(5).getClass(), SmtpClientRespDecoder.class, "expected class mismatched.");
 
         // verify GenericFutureListener.operationComplete()
         final GenericFutureListener listener = listenerCaptor.getAllValues().get(0);
@@ -1271,9 +1290,10 @@ public class SmtpAsyncClientTest {
 
 
         final ArgumentCaptor<ChannelHandler> handlerCaptorLast = ArgumentCaptor.forClass(ChannelHandler.class);
-        Mockito.verify(nettyPipeline, Mockito.times(1)).addLast(Mockito.anyString(), handlerCaptorLast.capture());
-        Assert.assertEquals(handlerCaptorLast.getAllValues().size(), 1, "Unexpected count of ChannelHandler added.");
-        Assert.assertEquals(handlerCaptorLast.getAllValues().get(0).getClass(), SmtpClientConnectHandler.class, "expected class mismatched.");
+        Mockito.verify(nettyPipeline, Mockito.times(2)).addLast(Mockito.anyString(), handlerCaptorLast.capture());
+        Assert.assertEquals(handlerCaptorLast.getAllValues().size(), 2, "Unexpected count of ChannelHandler added.");
+        Assert.assertEquals(handlerCaptorLast.getAllValues().get(1).getClass(), SmtpClientConnectHandler.class, "expected class mismatched.");
+        Assert.assertEquals(handlerCaptorLast.getAllValues().get(0).getClass(), ChunkedWriteHandler.class, "expected class mismatched.");
 
         // verify logging messages
         Mockito.verify(logger, Mockito.times(1)).debug(Mockito.eq(

--- a/core/src/test/java/com/yahoo/smtpnio/async/internal/SmtpAsyncSessionImplTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/internal/SmtpAsyncSessionImplTest.java
@@ -11,9 +11,12 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -84,6 +87,18 @@ public class SmtpAsyncSessionImplTest {
         {
             final SmtpRequest cmd = Mockito.mock(SmtpRequest.class);
             Mockito.when(cmd.getCommandLineBytes()).thenReturn(Unpooled.buffer().writeBytes("AUTH PLAIN\r\n".getBytes(StandardCharsets.US_ASCII)));
+            Mockito.doAnswer(new Answer() {
+                @Override
+                public Object answer(final InvocationOnMock invocationOnMock) throws Throwable {
+                    final Channel aChannel = invocationOnMock.getArgumentAt(0, Channel.class);
+                    final Supplier<ChannelPromise> promise = invocationOnMock.getArgumentAt(1, Supplier.class);
+                    final SmtpResponse response = invocationOnMock.getArgumentAt(2, SmtpResponse.class);
+
+                    aChannel.writeAndFlush(cmd.getNextCommandLineAfterContinuation(response), promise.get());
+
+                    return null;
+                }
+            }).when(cmd).encodeCommandAfterContinuation(Mockito.any(), Mockito.any(), Mockito.any());
 
             final SmtpFuture<SmtpAsyncResponse> future = aSession.execute(cmd);
             Mockito.verify(authWritePromise, Mockito.times(1)).addListener(Mockito.any(SmtpAsyncSessionImpl.class));

--- a/core/src/test/java/com/yahoo/smtpnio/async/internal/SmtpAsyncSessionImplTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/internal/SmtpAsyncSessionImplTest.java
@@ -341,6 +341,37 @@ public class SmtpAsyncSessionImplTest {
     }
 
     /**
+     * Tests that executing a request against a closed channel throws.
+     *
+     */
+    @Test
+    public void testClosedChannel() {
+        final Channel channel = Mockito.mock(Channel.class);
+        final ChannelPipeline pipeline = Mockito.mock(ChannelPipeline.class);
+        Mockito.when(channel.pipeline()).thenReturn(pipeline);
+        Mockito.when(channel.isActive()).thenReturn(false);
+        final ChannelPromise writePromise = Mockito.mock(ChannelPromise.class);
+        Mockito.when(channel.newPromise()).thenReturn(writePromise);
+
+        final Logger logger = Mockito.mock(Logger.class);
+        Mockito.when(logger.isDebugEnabled()).thenReturn(true);
+
+        // construct, turn on session level debugging by having logger.isDebugEnabled() true and session level debug on
+
+        final SmtpAsyncSessionImpl aSession = new SmtpAsyncSessionImpl(channel, logger, DebugMode.DEBUG_ON, SESSION_ID, pipeline, USER_ID);
+
+        // execute
+        final SmtpRequest cmd = new QuitCommand();
+
+        Assert.assertThrows(new Assert.ThrowingRunnable() {
+            @Override
+            public void run() throws Throwable {
+                aSession.execute(cmd);
+            }
+        });
+    }
+
+    /**
      * Tests server idles event happens while command queue is empty.
      */
     @Test

--- a/core/src/test/java/com/yahoo/smtpnio/async/request/DataCommandTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/request/DataCommandTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.mail.MessagingException;
+import javax.mail.Session;
+import javax.mail.internet.InternetAddress;
+
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.sun.mail.smtp.SMTPMessage;
+import com.yahoo.smtpnio.async.exception.SmtpAsyncClientException;
+import com.yahoo.smtpnio.async.response.SmtpResponse;
+
+/**
+ * Unit test for {@link DataCommand}.
+ */
+public class DataCommandTest {
+
+    /** Fields to check for cleanup. */
+    private final Set<Field> fieldsToCheck = new HashSet<>();
+
+    /**
+     * Setup reflection.
+     */
+    @BeforeClass
+    public void setUp() {
+        final Class<?> classUnderTest = DataCommand.class;
+        for (Class<?> c = classUnderTest; c != null; c = c.getSuperclass()) {
+            for (final Field declaredField : c.getDeclaredFields()) {
+                if (!declaredField.getType().isPrimitive() && !Modifier.isStatic(declaredField.getModifiers())) {
+                    declaredField.setAccessible(true);
+                    fieldsToCheck.add(declaredField);
+                }
+            }
+        }
+    }
+
+    /**
+     * Tests the trivial case of an empty message.
+     *
+     * @throws SmtpAsyncClientException will not throw in this test
+     * @throws IllegalAccessException will not throw in this test
+     * @throws MessagingException will not throw in this test
+     */
+    @Test
+    public void testGetCommandLineEmpty() throws SmtpAsyncClientException, IllegalAccessException, MessagingException {
+        SMTPMessage msg = new SMTPMessage((Session) null);
+        msg.setText("");
+        final SmtpRequest cmd = new DataCommand(msg);
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII), "DATA\r\n",
+                "Expected results mismatched");
+        final String message = cmd.getNextCommandLineAfterContinuation(new SmtpResponse("200 123-Not needed"))
+                .toString(StandardCharsets.US_ASCII);
+        Assert.assertTrue(message.endsWith("\r\n.\r\n"), "Incorrect ending");
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests the correctness of the constructor.
+     *
+     * @throws IllegalAccessException will not throw in this test
+     */
+    @Test
+    public void testConstructor() throws IllegalAccessException {
+        SMTPMessage msg = new SMTPMessage((Session) null);
+        final DataCommand cmd = new DataCommand(msg);
+        Assert.assertSame(cmd.getMessage(), msg, "Wrong message");
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+
+    /**
+     * Tests the correctness of the header content in a message.
+     *
+     * @throws SmtpAsyncClientException will not throw in this test
+     * @throws IllegalAccessException will not throw in this test
+     * @throws MessagingException will not throw in this test
+     */
+    @Test
+    public void testSetHeaders() throws SmtpAsyncClientException, IllegalAccessException, MessagingException {
+        SMTPMessage msg = new SMTPMessage((Session) null);
+        msg.setText("");
+
+        msg.setHeader("Cc", "Eric");
+        msg.setHeader("Bcc", "Alice");
+        msg.setHeader("From", "a good friend");
+        msg.setHeader("To", "my best friend");
+        msg.setSubject("long time no see!", "UTF-8");
+
+        final SmtpRequest cmd = new DataCommand(msg);
+
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII), "DATA\r\n",
+                "Expected results mismatched");
+        final String message = cmd.getNextCommandLineAfterContinuation(new SmtpResponse("200 123-Not needed"))
+                .toString(StandardCharsets.US_ASCII);
+
+        Assert.assertTrue(message.contains("Cc: Eric\r\n"), "Output does not contain the expected string");
+        Assert.assertTrue(message.contains("Bcc: Alice\r\n"), "Output does not contain the expected string");
+        Assert.assertTrue(message.contains("From: a good friend\r\n"), "Output does not contain the expected string");
+        Assert.assertTrue(message.contains("To: my best friend\r\n"), "Output does not contain the expected string");
+        Assert.assertTrue(message.contains("Subject: long time no see!\r\n"), "Output does not contain the expected string");
+
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests for the correctness of the body content of a message.
+     *
+     * @throws SmtpAsyncClientException will not throw in this test
+     * @throws IllegalAccessException will not throw in this test
+     * @throws MessagingException will not throw in this test
+     */
+    @Test
+    public void testSetBody() throws SmtpAsyncClientException, IllegalAccessException, MessagingException {
+        SMTPMessage msg = new SMTPMessage((Session) null);
+        msg.setText("Hi Bart,\n\nThis is a reminder that you have outstanding payments due soon.");
+        final SmtpRequest cmd = new DataCommand(msg);
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII), "DATA\r\n",
+                "Expected results mismatched");
+        final String message = cmd.getNextCommandLineAfterContinuation(new SmtpResponse("200 123-Not needed"))
+                .toString(StandardCharsets.US_ASCII);
+        Assert.assertTrue(message.contains("\r\nHi Bart,\n\nThis is a reminder that you have outstanding payments due soon.\r\n.\r\n"),
+                "Output does not contain the expected string");
+
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests the correctness of the body content of a message with non-ascii characters.
+     *
+     * @throws SmtpAsyncClientException will not throw in this test
+     * @throws IOException will not throw in this test
+     * @throws MessagingException will not throw in this test
+     */
+    @Test
+    public void testSetBodyComplex() throws SmtpAsyncClientException, IOException, MessagingException {
+        final SMTPMessage msg = new SMTPMessage((Session) null);
+        msg.setFrom(new InternetAddress("testing123@example.net", "John Smith"));
+        msg.setSubject("Hello World!", String.valueOf(StandardCharsets.UTF_8));
+        msg.setText("哈咯，这是一些中文测试子。कुछ हिंदी पाठ", String.valueOf(StandardCharsets.UTF_8));
+
+        final DataCommand cmd = new DataCommand(msg);
+        Assert.assertSame(msg, cmd.getMessage());
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII), "DATA\r\n",
+                "Expected results mismatched");
+
+        // actual output
+        final String message = cmd.getNextCommandLineAfterContinuation(new SmtpResponse("354 Go Ahead")).toString(StandardCharsets.UTF_8);
+
+        // Expected
+        final ByteArrayOutputStream output = new ByteArrayOutputStream();
+        msg.writeTo(output);
+        final String rawEmail = output.toString();
+
+        Assert.assertEquals(message.substring(0, message.length() - 5), rawEmail); // strip away the terminating chars
+        Assert.assertTrue(message.endsWith("\r\n.\r\n"));
+    }
+
+    /**
+     * Tests the behavior of {@code getNextCommandLineAfterContinuation} when given a bad response.
+     *
+     * @throws IOException will not throw in this test
+     * @throws MessagingException will not throw in this test
+     * @throws SmtpAsyncClientException will not throw in this test
+     */
+    @Test
+    public void testSmtpMessageFail() throws IOException, MessagingException, SmtpAsyncClientException {
+        final SMTPMessage msg = Mockito.mock(SMTPMessage.class);
+        final DataCommand cmd = new DataCommand(msg);
+
+        Mockito.doThrow(new IOException()).when(msg).writeTo(Mockito.any());
+        Assert.assertNull(cmd.getNextCommandLineAfterContinuation(new SmtpResponse("555 bad")));
+
+        Mockito.doThrow(new MessagingException()).when(msg).writeTo(Mockito.any());
+        Assert.assertNull(cmd.getNextCommandLineAfterContinuation(new SmtpResponse("555 bad")));
+    }
+
+    /**
+     * Tests the {@code getCommandType} method.
+     */
+    @Test
+    public void testGetCommandType() {
+        Assert.assertSame(new DataCommand(new SMTPMessage((Session) null)).getCommandType(), SmtpRFCSupportedCommandType.DATA);
+    }
+
+    /**
+     * Tests the {@code isCommandLineSensitive} method.
+     */
+    @Test
+    public void testIsCommandSensitive() {
+        Assert.assertFalse(new DataCommand(new SMTPMessage((Session) null)).isCommandLineDataSensitive());
+    }
+
+    /**\
+     * Tests the {@code getDebugData} method.
+     */
+    @Test
+    public void testGetDebugData() {
+        Assert.assertEquals(new DataCommand(new SMTPMessage((Session) null)).getDebugData(), "");
+    }
+}

--- a/core/src/test/java/com/yahoo/smtpnio/async/request/DataStreamCommandTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/request/DataStreamCommandTest.java
@@ -28,7 +28,6 @@ import com.sun.mail.smtp.SMTPMessage;
 import com.yahoo.smtpnio.async.exception.SmtpAsyncClientException;
 import com.yahoo.smtpnio.async.response.SmtpResponse;
 
-import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.stream.ChunkedStream;
@@ -169,7 +168,6 @@ public class DataStreamCommandTest {
         }, Mockito.mock(SmtpResponse.class));
 
         Mockito.verify(channel, Mockito.times(1)).write(Mockito.any(ChunkedStream.class), Mockito.eq(channelPromise));
-        Mockito.verify(channel, Mockito.times(1)).writeAndFlush(Mockito.any(ByteBuf.class));
 
         cmd.cleanup();
         // Verify if cleanup happened correctly.

--- a/core/src/test/java/com/yahoo/smtpnio/async/request/DataStreamCommandTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/request/DataStreamCommandTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import javax.mail.MessagingException;
+import javax.mail.Session;
+
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.sun.mail.smtp.SMTPMessage;
+import com.yahoo.smtpnio.async.exception.SmtpAsyncClientException;
+import com.yahoo.smtpnio.async.response.SmtpResponse;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.stream.ChunkedStream;
+
+/**
+ * Unit test for {@link DataCommand}.
+ */
+public class DataStreamCommandTest {
+
+    /** Fields to check for cleanup. */
+    private final Set<Field> fieldsToCheck = new HashSet<>();
+
+    /**
+     * Setup reflection.
+     */
+    @BeforeClass
+    public void setUp() {
+        final Class<?> classUnderTest = DataStreamCommand.class;
+        for (Class<?> c = classUnderTest; c != null; c = c.getSuperclass()) {
+            for (final Field declaredField : c.getDeclaredFields()) {
+                if (!declaredField.getType().isPrimitive() && !Modifier.isStatic(declaredField.getModifiers())) {
+                    declaredField.setAccessible(true);
+                    fieldsToCheck.add(declaredField);
+                }
+            }
+        }
+    }
+
+    /**
+     * Tests the correctness of the constructor.
+     *
+     * @throws IllegalAccessException will not throw in this test
+     */
+    @Test
+    public void testConstructor() throws IllegalAccessException {
+        final ByteArrayInputStream payload = new ByteArrayInputStream("data".getBytes());
+        final DataStreamCommand cmd = new DataStreamCommand(payload);
+        Assert.assertSame(cmd.getMessage(), payload, "Wrong message");
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+
+    /**
+     * Tests the correctness of the header content in a message.
+     *
+     * @throws SmtpAsyncClientException will not throw in this test
+     * @throws IllegalAccessException will not throw in this test
+     * @throws MessagingException will not throw in this test
+     * @throws IOException will not throw in this test
+     */
+    @Test
+    public void testSetHeaders() throws SmtpAsyncClientException, IllegalAccessException, MessagingException, IOException {
+        SMTPMessage msg = new SMTPMessage((Session) null);
+        msg.setText("");
+
+        msg.setHeader("Cc", "Eric");
+        msg.setHeader("Bcc", "Alice");
+        msg.setHeader("From", "a good friend");
+        msg.setHeader("To", "my best friend");
+        msg.setSubject("long time no see!", "UTF-8");
+        final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        msg.writeTo(byteArrayOutputStream);
+        final SmtpRequest cmd = new DataStreamCommand(new ByteArrayInputStream(byteArrayOutputStream.toByteArray()));
+
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII), "DATA\r\n",
+                "Expected results mismatched");
+        final String message = cmd.getNextCommandLineAfterContinuation(new SmtpResponse("200 123-Not needed"))
+                .toString(StandardCharsets.US_ASCII);
+
+        Assert.assertTrue(message.contains("Cc: Eric\r\n"), "Output does not contain the expected string");
+        Assert.assertTrue(message.contains("Bcc: Alice\r\n"), "Output does not contain the expected string");
+        Assert.assertTrue(message.contains("From: a good friend\r\n"), "Output does not contain the expected string");
+        Assert.assertTrue(message.contains("To: my best friend\r\n"), "Output does not contain the expected string");
+        Assert.assertTrue(message.contains("Subject: long time no see!\r\n"), "Output does not contain the expected string");
+
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests that errors are propagated.
+     *
+     * @throws IOException will not throw in this test
+     */
+    @Test
+    public void testWritingFails() throws IOException {
+        final SmtpRequest cmd = new DataStreamCommand(new FileInputStream(Files.createTempFile("prefix", "suffix").toFile()) {
+            @Override
+            public synchronized int read(final byte[] b) throws IOException {
+                throw new IOException("Fails");
+            }
+        });
+
+        Assert.assertThrows(new Assert.ThrowingRunnable() {
+            @Override
+            public void run() throws Throwable {
+                cmd.getNextCommandLineAfterContinuation(new SmtpResponse("200 123-Not needed"));
+            }
+        });
+    }
+
+    /**
+     * Tests the correctness of encodeCommandAfterContinuation.
+     *
+     * @throws SmtpAsyncClientException will not throw in this test
+     * @throws IllegalAccessException will not throw in this test
+     * @throws MessagingException will not throw in this test
+     * @throws IOException will not throw in this test
+     */
+    @Test
+    public void testEncodeCommandAfterContinuation() throws SmtpAsyncClientException, IllegalAccessException, MessagingException, IOException {
+        SMTPMessage msg = new SMTPMessage((Session) null);
+        msg.setText("");
+
+        msg.setHeader("Cc", "Eric");
+        msg.setHeader("Bcc", "Alice");
+        msg.setHeader("From", "a good friend");
+        msg.setHeader("To", "my best friend");
+        msg.setSubject("long time no see!", "UTF-8");
+        final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        msg.writeTo(byteArrayOutputStream);
+        final SmtpRequest cmd = new DataStreamCommand(new ByteArrayInputStream(byteArrayOutputStream.toByteArray()));
+
+        final Channel channel = Mockito.mock(Channel.class);
+        final ChannelPromise channelPromise = Mockito.mock(ChannelPromise.class);
+        cmd.encodeCommandAfterContinuation(channel, new Supplier<ChannelPromise>() {
+            @Override
+            public ChannelPromise get() {
+                return channelPromise;
+            }
+        }, Mockito.mock(SmtpResponse.class));
+
+        Mockito.verify(channel, Mockito.times(1)).write(Mockito.any(ChunkedStream.class), Mockito.eq(channelPromise));
+        Mockito.verify(channel, Mockito.times(1)).writeAndFlush(Mockito.any(ByteBuf.class));
+
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests the {@code getCommandType} method.
+     */
+    @Test
+    public void testGetCommandType() {
+        Assert.assertSame(new DataStreamCommand(new ByteArrayInputStream("".getBytes())).getCommandType(), SmtpRFCSupportedCommandType.DATA);
+    }
+
+    /**
+     * Tests the {@code isCommandLineSensitive} method.
+     */
+    @Test
+    public void testIsCommandSensitive() {
+        Assert.assertTrue(new DataStreamCommand(new ByteArrayInputStream("".getBytes())).isCommandLineDataSensitive());
+    }
+
+    /**\
+     * Tests the {@code getDebugData} method.
+     */
+    @Test
+    public void testGetDebugData() {
+        Assert.assertEquals(new DataStreamCommand(new ByteArrayInputStream("".getBytes())).getDebugData(), "DATA stream");
+    }
+
+
+    /**\
+     * Tests the {@code cleanup} method when closing the stream fails.
+     */
+    @Test
+    public void testCloseShouldSwallowFailure() {
+        final ByteArrayInputStream message = new ByteArrayInputStream("".getBytes()) {
+            /**
+             * Just throw an exception
+             *
+             * @throws IOException just throws
+             */
+            @Override
+            public void close() throws IOException {
+                throw new IOException("exception");
+            }
+        };
+        new DataStreamCommand(message).cleanup();
+    }
+
+}

--- a/core/src/test/java/com/yahoo/smtpnio/async/request/ExpandCommandTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/request/ExpandCommandTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.yahoo.smtpnio.async.exception.SmtpAsyncClientException;
+import com.yahoo.smtpnio.async.response.SmtpResponse;
+
+/**
+ * Unit test for {@link ExpandCommand}.
+ */
+public class ExpandCommandTest {
+
+    /** Fields to check for cleanup. */
+    private final Set<Field> fieldsToCheck = new HashSet<>();
+
+    /**
+     * Setup reflection.
+     */
+    @BeforeClass
+    public void setUp() {
+        final Class<?> classUnderTest = ExpandCommand.class;
+        for (Class<?> c = classUnderTest; c != null; c = c.getSuperclass()) {
+            for (final Field declaredField : c.getDeclaredFields()) {
+                if (!declaredField.getType().isPrimitive() && !Modifier.isStatic(declaredField.getModifiers())) {
+                    declaredField.setAccessible(true);
+                    fieldsToCheck.add(declaredField);
+                }
+            }
+        }
+    }
+
+    /**
+     * Tests the correctness of the commandline content.
+     *
+     * @throws SmtpAsyncClientException will not throw in a successful test
+     * @throws IllegalAccessException will not throw in a successful test
+     */
+    @Test
+    public void testGetCommandLine() throws SmtpAsyncClientException, IllegalAccessException {
+        final SmtpRequest cmd = new ExpandCommand();
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII),
+                "EXPN\r\n", "Expected results mismatched");
+        Assert.assertFalse(cmd.isCommandLineDataSensitive());
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests the {@code getCommandType} method.
+     */
+    @Test
+    public void testGetCommandType() {
+        Assert.assertSame(new ExpandCommand().getCommandType(), SmtpRFCSupportedCommandType.EXPN);
+    }
+
+    /**
+     * Test the behavior of the {@code getNextCommandLineAfterContinuation} method, as well as the correctness of the corresponding exception thrown.
+     */
+    @Test
+    public void testGetNextCommandLineAfterContinuation() {
+        final SmtpRequest cmd = new ExpandCommand();
+        try {
+            cmd.getNextCommandLineAfterContinuation(new SmtpResponse("400 resp"));
+            Assert.fail("Exception should've been thrown");
+        } catch (SmtpAsyncClientException ex) {
+            Assert.assertEquals(ex.getFailureType(), SmtpAsyncClientException.FailureType.OPERATION_NOT_SUPPORTED_FOR_COMMAND);
+        }
+    }
+
+    /**
+     * Tests the {@code getDebugData} method.
+     */
+    @Test
+    public void testGetDebugData() {
+        Assert.assertEquals(new ExpandCommand().getDebugData(), "");
+    }
+}

--- a/core/src/test/java/com/yahoo/smtpnio/async/request/HelpCommandTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/request/HelpCommandTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.yahoo.smtpnio.async.exception.SmtpAsyncClientException;
+import com.yahoo.smtpnio.async.response.SmtpResponse;
+
+/**
+ * Unit test for {@link HelpCommand}.
+ */
+public class HelpCommandTest {
+
+    /** Fields to check for cleanup. */
+    private final Set<Field> fieldsToCheck = new HashSet<>();
+
+    /**
+     * Setup reflection.
+     */
+    @BeforeClass
+    public void setUp() {
+        final Class<?> classUnderTest = HelpCommand.class;
+        for (Class<?> c = classUnderTest; c != null; c = c.getSuperclass()) {
+            for (final Field declaredField : c.getDeclaredFields()) {
+                if (!declaredField.getType().isPrimitive() && !Modifier.isStatic(declaredField.getModifiers())) {
+                    declaredField.setAccessible(true);
+                    fieldsToCheck.add(declaredField);
+                }
+            }
+        }
+    }
+
+    /**
+     * Tests the correctness of the command line content.
+     *
+     * @throws SmtpAsyncClientException will not throw in a successful test
+     * @throws IllegalAccessException will not throw in a successful test
+     */
+    @Test
+    public void testGetCommandLine() throws SmtpAsyncClientException, IllegalAccessException {
+        final SmtpRequest cmd = new HelpCommand();
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII),
+                "HELP\r\n", "Expected results mismatched");
+        Assert.assertFalse(cmd.isCommandLineDataSensitive());
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests the {@code getCommandType} method.
+     */
+    @Test
+    public void testGetCommandType() {
+        Assert.assertSame(new HelpCommand().getCommandType(), SmtpRFCSupportedCommandType.HELP);
+    }
+
+    /**
+     * Test the behavior of the {@code getNextCommandLineAfterContinuation} method, as well as the correctness of the corresponding exception thrown.
+     */
+    @Test
+    public void testGetNextCommandLineAfterContinuation() {
+        final SmtpRequest cmd = new HelpCommand();
+        try {
+            cmd.getNextCommandLineAfterContinuation(new SmtpResponse("400 resp"));
+            Assert.fail("Exception should've been thrown");
+        } catch (SmtpAsyncClientException ex) {
+            Assert.assertEquals(ex.getFailureType(), SmtpAsyncClientException.FailureType.OPERATION_NOT_SUPPORTED_FOR_COMMAND);
+        }
+    }
+
+    /**
+     * Tests the {@code getDebugData} method.
+     */
+    @Test
+    public void testGetDebugData() {
+        Assert.assertEquals(new QuitCommand().getDebugData(), "");
+    }
+}

--- a/core/src/test/java/com/yahoo/smtpnio/async/request/MailCommandTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/request/MailCommandTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Set;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.yahoo.smtpnio.async.exception.SmtpAsyncClientException;
+import com.yahoo.smtpnio.async.response.SmtpResponse;
+
+/**
+ * Unit test for {@link MailCommand}.
+ */
+public class MailCommandTest {
+
+    /** Fields to check for cleanup. */
+    private final Set<Field> fieldsToCheck = new HashSet<>();
+
+    /**
+     * Setup reflection.
+     */
+    @BeforeClass
+    public void setUp() {
+        final Class<?> classUnderTest = MailCommand.class;
+        for (Class<?> c = classUnderTest; c != null; c = c.getSuperclass()) {
+            for (final Field declaredField : c.getDeclaredFields()) {
+                if (!declaredField.getType().isPrimitive() && !Modifier.isStatic(declaredField.getModifiers())) {
+                    declaredField.setAccessible(true);
+                    fieldsToCheck.add(declaredField);
+                }
+            }
+        }
+    }
+
+    /**
+     * Tests the basic functionality with a stub command.
+     *
+     * @throws SmtpAsyncClientException will not throw
+     * @throws IllegalAccessException will not throw
+     */
+    @Test
+    public void testGetCommandLine() throws SmtpAsyncClientException, IllegalAccessException {
+        final SmtpRequest cmd = new MailCommand("user1.test@yahoo.com");
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII),
+                "MAIL FROM:<user1.test@yahoo.com>\r\n", "Expected results mismatched");
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII),
+                "MAIL" + SmtpClientConstants.SPACE + "FROM" + SmtpClientConstants.COLON
+                        + SmtpClientConstants.L_ANGLE_BRACKET + "user1.test@yahoo.com" + SmtpClientConstants.R_ANGLE_BRACKET
+                        + SmtpClientConstants.CRLF,
+                "Expected results mismatched");
+        Assert.assertFalse(cmd.isCommandLineDataSensitive());
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests the constructor with no arguments. It should use the string as the sender (aka. reverse-path).
+     *
+     * @throws SmtpAsyncClientException will not throw
+     * @throws IllegalAccessException will not throw
+     */
+    @Test
+    public void testGetCommandLineDefaultConstructor() throws SmtpAsyncClientException, IllegalAccessException {
+        final SmtpRequest cmd = new MailCommand();
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII),
+                "MAIL FROM:<>\r\n", "Expected results mismatched");
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII),
+                "MAIL" + SmtpClientConstants.SPACE + "FROM" + SmtpClientConstants.COLON
+                        + SmtpClientConstants.L_ANGLE_BRACKET + SmtpClientConstants.R_ANGLE_BRACKET + SmtpClientConstants.CRLF,
+                "Expected results mismatched");
+        Assert.assertFalse(cmd.isCommandLineDataSensitive());
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests the constructor taking in just the sender, the result should not have any additional arguments or trailing spaces.
+     *
+     * @throws SmtpAsyncClientException will not throw
+     * @throws IllegalAccessException will not throw
+     */
+    @Test
+    public void testNoMailParameter() throws SmtpAsyncClientException, IllegalAccessException {
+        final SmtpRequest cmd = new MailCommand("alice");
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII),
+                "MAIL FROM:<alice>\r\n", "Expected results mismatched");
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests the constructor taking in only an empty collection of {@link MailCommand.MailParameter}, its behavior should be set the
+     * the sender as the empty string and have no additional arguments after or trailing spaces.
+     *
+     * @throws SmtpAsyncClientException will not throw
+     * @throws IllegalAccessException will not throw
+     */
+    @Test
+    public void testOnlyMailParameterEmpty() throws SmtpAsyncClientException, IllegalAccessException {
+        final SmtpRequest cmd = new MailCommand(new LinkedList<>());
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII),
+                "MAIL FROM:<>\r\n", "Expected results mismatched");
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests the constructor taking in a sender and an empty collection of {@link MailCommand.MailParameter}, its behavior should be
+     * identical to the constructor without the mail parameters.
+     *
+     * @throws SmtpAsyncClientException will not throw
+     * @throws IllegalAccessException will not throw
+     */
+    @Test
+    public void testMailParameterEmpty() throws SmtpAsyncClientException, IllegalAccessException {
+        final SmtpRequest cmd = new MailCommand("bob", new ArrayList<>());
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII),
+                "MAIL FROM:<bob>\r\n", "Expected results mismatched");
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests the constructor taking in both the sender and a non-empty collection of {@link MailCommand.MailParameter}, the result
+     * should follow the RFC standards.
+     *
+     * @throws SmtpAsyncClientException will not throw
+     * @throws IllegalAccessException will not throw
+     */
+    @Test
+    public void testMailParameter() throws SmtpAsyncClientException, IllegalAccessException {
+        final SmtpRequest cmd = new MailCommand("bob", new ArrayList<MailCommand.MailParameter>() { {
+            add(new MailCommand.MailParameter("AUTH", "value"));
+            add(new MailCommand.MailParameter("Just_key"));
+            add(new MailCommand.MailParameter("key2"));
+        } });
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII),
+                "MAIL FROM:<bob> AUTH=value Just_key key2\r\n", "Expected results mismatched");
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Another test for the constructor taking in both the sender and a non-empty collection of {@link MailCommand.MailParameter}, the result
+     * should follow the RFC standards.
+     *
+     * @throws SmtpAsyncClientException will not throw
+     * @throws IllegalAccessException will not throw
+     */
+    @Test
+    public void testMailParameter2() throws SmtpAsyncClientException, IllegalAccessException {
+        final SmtpRequest cmd = new MailCommand(new LinkedList<MailCommand.MailParameter>() { {
+            add(new MailCommand.MailParameter("key1"));
+            add(new MailCommand.MailParameter("key2"));
+            add(new MailCommand.MailParameter("key3", "value3"));
+        } });
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII),
+                "MAIL FROM:<> key1 key2 key3=value3\r\n", "Expected results mismatched");
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests the {@code getCommandType} method.
+     */
+    @Test
+    public void testGetCommandType() {
+        Assert.assertSame(new MailCommand("example@verizonmedia.com").getCommandType(), SmtpRFCSupportedCommandType.MAIL);
+    }
+
+    /**
+     * Tests the {@code getNextCommandLineAfterContinuation} method.
+     */
+    @Test
+    public void testGetNextCommandLineAfterContinuation() {
+        final SmtpRequest cmd = new MailCommand("test.sender@example.net");
+        try {
+            cmd.getNextCommandLineAfterContinuation(new SmtpResponse("400 resp"));
+            Assert.fail("Exception should've been thrown");
+        } catch (SmtpAsyncClientException ex) {
+            Assert.assertEquals(ex.getFailureType(), SmtpAsyncClientException.FailureType.OPERATION_NOT_SUPPORTED_FOR_COMMAND);
+        }
+    }
+
+    /**
+     * Tests the {@code getDebugData} method.
+     */
+    @Test
+    public void testGetDebugData() {
+        Assert.assertEquals(new MailCommand("test.sender@example.net").getDebugData(), "");
+    }
+}

--- a/core/src/test/java/com/yahoo/smtpnio/async/request/NoopCommandTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/request/NoopCommandTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.yahoo.smtpnio.async.exception.SmtpAsyncClientException;
+import com.yahoo.smtpnio.async.response.SmtpResponse;
+
+/**
+ * Unit test for {@link NoopCommand}.
+ */
+public class NoopCommandTest {
+
+    /** Fields to check for cleanup. */
+    private final Set<Field> fieldsToCheck = new HashSet<>();
+
+    /**
+     * Setup reflection.
+     */
+    @BeforeClass
+    public void setUp() {
+        final Class<?> classUnderTest = NoopCommand.class;
+        for (Class<?> c = classUnderTest; c != null; c = c.getSuperclass()) {
+            for (final Field declaredField : c.getDeclaredFields()) {
+                if (!declaredField.getType().isPrimitive() && !Modifier.isStatic(declaredField.getModifiers())) {
+                    declaredField.setAccessible(true);
+                    fieldsToCheck.add(declaredField);
+                }
+            }
+        }
+    }
+
+    /**
+     * Tests the correctness of the command line content.
+     *
+     * @throws SmtpAsyncClientException will not throw
+     * @throws IllegalAccessException will not throw
+     * @throws IllegalArgumentException will not throw
+     */
+    @Test
+    public void testGetCommandLine() throws SmtpAsyncClientException, IllegalArgumentException, IllegalAccessException {
+        final SmtpRequest cmd = new NoopCommand();
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII),
+                "NOOP\r\n", "Expected result mismatched.");
+        Assert.assertFalse(cmd.isCommandLineDataSensitive());
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests getCommandType method.
+     */
+    @Test
+    public void testGetCommandType() {
+        Assert.assertSame(new NoopCommand().getCommandType(), SmtpRFCSupportedCommandType.NOOP);
+    }
+
+    /**
+     * Test the behavior of the {@code getNextCommandLineAfterContinuation} method, as well as the correctness of the corresponding exception thrown.
+     */
+    @Test
+    public void testGetNextCommandLineAfterContinuation() {
+        final SmtpRequest cmd = new NoopCommand();
+        try {
+            cmd.getNextCommandLineAfterContinuation(new SmtpResponse("400 resp"));
+            Assert.fail("Exception should've been thrown");
+        } catch (SmtpAsyncClientException ex) {
+            Assert.assertEquals(ex.getFailureType(), SmtpAsyncClientException.FailureType.OPERATION_NOT_SUPPORTED_FOR_COMMAND);
+        }
+    }
+
+    /**
+     * Tests the {@code getDebugData} method.
+     */
+    @Test
+    public void testGetDebugData() {
+        Assert.assertEquals(new NoopCommand().getDebugData(), "");
+    }
+}

--- a/core/src/test/java/com/yahoo/smtpnio/async/request/RecipientCommandTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/request/RecipientCommandTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.yahoo.smtpnio.async.exception.SmtpAsyncClientException;
+import com.yahoo.smtpnio.async.response.SmtpResponse;
+
+/**
+ * Unit test for {@link RecipientCommand}.
+ */
+public class RecipientCommandTest {
+
+    /** Fields to check for cleanup. */
+    private final Set<Field> fieldsToCheck = new HashSet<>();
+
+    /**
+     * Setup reflection.
+     */
+    @BeforeClass
+    public void setUp() {
+        final Class<?> classUnderTest = RecipientCommand.class;
+        for (Class<?> c = classUnderTest; c != null; c = c.getSuperclass()) {
+            for (final Field declaredField : c.getDeclaredFields()) {
+                if (!declaredField.getType().isPrimitive() && !Modifier.isStatic(declaredField.getModifiers())) {
+                    declaredField.setAccessible(true);
+                    fieldsToCheck.add(declaredField);
+                }
+            }
+        }
+    }
+
+    /**
+     * Tests the correctness of the command line content.
+     *
+     * @throws SmtpAsyncClientException will not throw in a successful test
+     * @throws IllegalAccessException will not throw in a successful test
+     */
+    @Test
+    public void testGetCommandLine() throws SmtpAsyncClientException, IllegalAccessException {
+        final SmtpRequest cmd = new RecipientCommand("recipient.address@example.com");
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII),
+                "RCPT TO:<recipient.address@example.com>\r\n", "Expected results mismatched");
+        Assert.assertFalse(cmd.isCommandLineDataSensitive());
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests the {@code getCommandType} method.
+     */
+    @Test
+    public void testGetCommandType() {
+        Assert.assertSame(new RecipientCommand("any").getCommandType(), SmtpRFCSupportedCommandType.RCPT);
+    }
+
+    /**
+     * Test the behavior of the {@code getNextCommandLineAfterContinuation} method, as well as the correctness of the corresponding exception thrown.
+     */
+    @Test
+    public void testGetNextCommandLineAfterContinuation() {
+        final SmtpRequest cmd = new RecipientCommand("receiver");
+        try {
+            cmd.getNextCommandLineAfterContinuation(new SmtpResponse("400 resp"));
+            Assert.fail("Exception should've been thrown");
+        } catch (SmtpAsyncClientException ex) {
+            Assert.assertEquals(ex.getFailureType(), SmtpAsyncClientException.FailureType.OPERATION_NOT_SUPPORTED_FOR_COMMAND);
+        }
+    }
+
+    /**
+     * Tests the {@code getDebugData} method.
+     */
+    @Test
+    public void testGetDebugData() {
+        Assert.assertEquals(new RecipientCommand("receiver").getDebugData(), "");
+    }
+}

--- a/core/src/test/java/com/yahoo/smtpnio/async/request/ResetCommandTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/request/ResetCommandTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.yahoo.smtpnio.async.exception.SmtpAsyncClientException;
+import com.yahoo.smtpnio.async.response.SmtpResponse;
+
+/**
+ * Unit test for {@link ResetCommand}.
+ */
+public class ResetCommandTest {
+
+    /** Fields to check for cleanup. */
+    private final Set<Field> fieldsToCheck = new HashSet<>();
+
+    /**
+     * Setup reflection.
+     */
+    @BeforeClass
+    public void setUp() {
+        final Class<?> classUnderTest = ResetCommand.class;
+        for (Class<?> c = classUnderTest; c != null; c = c.getSuperclass()) {
+            for (final Field declaredField : c.getDeclaredFields()) {
+                if (!declaredField.getType().isPrimitive() && !Modifier.isStatic(declaredField.getModifiers())) {
+                    declaredField.setAccessible(true);
+                    fieldsToCheck.add(declaredField);
+                }
+            }
+        }
+    }
+
+    /**
+     * Tests the correctness of the command line content.
+     *
+     * @throws SmtpAsyncClientException will not throw in a successful test
+     * @throws IllegalAccessException will not throw in a successful test
+     */
+    @Test
+    public void testGetCommandLine() throws SmtpAsyncClientException, IllegalAccessException {
+        final SmtpRequest cmd = new ResetCommand();
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII),
+                "RSET\r\n", "Expected results mismatched");
+        Assert.assertFalse(cmd.isCommandLineDataSensitive());
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests the {@code getCommandType} method.
+     */
+    @Test
+    public void testGetCommandType() {
+        Assert.assertSame(new ResetCommand().getCommandType(), SmtpRFCSupportedCommandType.RSET);
+    }
+
+    /**
+     * Test the behavior of the {@code getNextCommandLineAfterContinuation} method, as well as the correctness of the corresponding exception thrown.
+     */
+    @Test
+    public void testGetNextCommandLineAfterContinuation() {
+        final SmtpRequest cmd = new ResetCommand();
+        try {
+            cmd.getNextCommandLineAfterContinuation(new SmtpResponse("400 resp"));
+            Assert.fail("Exception should've been thrown");
+        } catch (SmtpAsyncClientException ex) {
+            Assert.assertEquals(ex.getFailureType(), SmtpAsyncClientException.FailureType.OPERATION_NOT_SUPPORTED_FOR_COMMAND);
+        }
+    }
+
+    /**
+     * Tests the {@code getDebugData} method.
+     */
+    @Test
+    public void testGetDebugData() {
+        Assert.assertEquals(new ResetCommand().getDebugData(), "");
+    }
+}

--- a/core/src/test/java/com/yahoo/smtpnio/async/request/VerifyCommandTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/request/VerifyCommandTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Verizon Media
+ * Licensed under the terms of the Apache 2.0 license. See LICENSE file in project root for terms.
+ */
+package com.yahoo.smtpnio.async.request;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.yahoo.smtpnio.async.exception.SmtpAsyncClientException;
+import com.yahoo.smtpnio.async.response.SmtpResponse;
+
+/**
+ * Unit test for {@link VerifyCommand}.
+ */
+public class VerifyCommandTest {
+
+    /** Fields to check for cleanup. */
+    private final Set<Field> fieldsToCheck = new HashSet<>();
+
+    /**
+     * Setup reflection.
+     */
+    @BeforeClass
+    public void setUp() {
+        final Class<?> classUnderTest = VerifyCommand.class;
+        for (Class<?> c = classUnderTest; c != null; c = c.getSuperclass()) {
+            for (final Field declaredField : c.getDeclaredFields()) {
+                if (!declaredField.getType().isPrimitive() && !Modifier.isStatic(declaredField.getModifiers())) {
+                    declaredField.setAccessible(true);
+                    fieldsToCheck.add(declaredField);
+                }
+            }
+        }
+    }
+
+    /**
+     * Tests the correctness of the command line content.
+     *
+     * @throws SmtpAsyncClientException will not throw in a successful test
+     * @throws IllegalAccessException will not throw in a successful test
+     */
+    @Test
+    public void testGetCommandLine() throws SmtpAsyncClientException, IllegalAccessException {
+        final SmtpRequest cmd = new VerifyCommand();
+        Assert.assertEquals(cmd.getCommandLineBytes().toString(StandardCharsets.US_ASCII),
+                "VRFY\r\n", "Expected results mismatched");
+        Assert.assertFalse(cmd.isCommandLineDataSensitive());
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests the {@code getCommandType} method.
+     */
+    @Test
+    public void testGetCommandType() {
+        Assert.assertSame(new VerifyCommand().getCommandType(), SmtpRFCSupportedCommandType.VRFY);
+    }
+
+    /**
+     * Test the behavior of the {@code getNextCommandLineAfterContinuation} method, as well as the correctness of the corresponding exception thrown.
+     */
+    @Test
+    public void testGetNextCommandLineAfterContinuation() {
+        final SmtpRequest cmd = new VerifyCommand();
+        try {
+            cmd.getNextCommandLineAfterContinuation(new SmtpResponse("400 resp"));
+            Assert.fail("Exception should've been thrown");
+        } catch (SmtpAsyncClientException ex) {
+            Assert.assertEquals(ex.getFailureType(), SmtpAsyncClientException.FailureType.OPERATION_NOT_SUPPORTED_FOR_COMMAND);
+        }
+    }
+
+    /**
+     * Tests the {@code getDebugData} method.
+     */
+    @Test
+    public void testGetDebugData() {
+        Assert.assertEquals(new VerifyCommand().getDebugData(), "");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.yahoo.smtpnio</groupId>
     <artifactId>smtpnio</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.10</version>
+    <version>1.1.0</version>
     <name>${project.artifactId}</name>
     <url>https://github.com/yahoo/smtp-client-nio</url>
     <description>Parent POM file for smtpnio project</description>


### PR DESCRIPTION
Follow up of https://github.com/yahoo/smtp-client-nio/pull/1

## Description

Implement usefull SMTP commands to actually make something of that library.

This includes a rebase, a rework to not have a hard dependency on javax.mail exposed to the user, and a POC of writing smtp message as imput stream to avoid full in-memory representation.

Last commit needs to be polished

## Motivation and Context

I want a Netty based library to write efficient email sending for Apache James.

## How Has This Been Tested?

TODO: 

 - [x] Use Dockerized fake smtp to validate content and commands (at least on my codde)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Major release (change is NOT backward compatible with prior release)

Writing a stream requires a breaking change: we can no longer always rely on the SMTP command being represented as a single ByteBuf.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes . 
- [x] All new and existing tests passed. 
