### PR TITLE
Remove duplicate chunked-writer handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This library is built and managed using [maven](https://maven.apache.org/what-is
 <dependency>
   <groupId>com.yahoo.smtpnio</groupId>
   <artifactId>smtpnio.core</artifactId>
-  <version>1.1.3</version>
+  <version>1.1.4</version>
 </dependency>
 ```
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.yahoo.smtpnio</groupId>
         <artifactId>smtpnio</artifactId>
-        <version>1.1.3</version>
+        <version>1.1.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/core/src/main/java/com/yahoo/smtpnio/async/client/SmtpAsyncClient.java
+++ b/core/src/main/java/com/yahoo/smtpnio/async/client/SmtpAsyncClient.java
@@ -43,7 +43,6 @@ import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
-import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.util.concurrent.GenericFutureListener;
 
 /**
@@ -227,7 +226,6 @@ public class SmtpAsyncClient {
                     pipeline.addFirst(SSL_HANDLER, sslHandler);
                     pipeline.addAfter(SSL_HANDLER, SslDetectHandler.HANDLER_NAME, new SslDetectHandler(sessionCount.get(), sessionData, config,
                             debugOption, smtpAsyncClient, sessionCreatedFuture));
-                    pipeline.addLast(CHUNKED_WRITER, new ChunkedWriteHandler());
                     pipeline.addLast(SmtpClientConnectHandler.HANDLER_NAME, new SmtpClientConnectHandler(sessionCreatedFuture,
                             debugOption, sessionId, sessionCtx));
                     break;

--- a/core/src/test/java/com/yahoo/smtpnio/async/client/SmtpAsyncClientTest.java
+++ b/core/src/test/java/com/yahoo/smtpnio/async/client/SmtpAsyncClientTest.java
@@ -157,10 +157,9 @@ public class SmtpAsyncClientTest {
         Assert.assertEquals(handlerCaptorAfter.getAllValues().get(0).getClass(), SslDetectHandler.class, "expected class mismatched.");
 
         final ArgumentCaptor<ChannelHandler> handlerCaptorLast = ArgumentCaptor.forClass(ChannelHandler.class);
-        Mockito.verify(nettyPipeline, Mockito.times(2)).addLast(Mockito.anyString(), handlerCaptorLast.capture());
-        Assert.assertEquals(handlerCaptorLast.getAllValues().size(), 2, "Unexpected count of ChannelHandler added.");
-        Assert.assertEquals(handlerCaptorLast.getAllValues().get(0).getClass(), ChunkedWriteHandler.class, "expected class mismatched.");
-        Assert.assertEquals(handlerCaptorLast.getAllValues().get(1).getClass(), SmtpClientConnectHandler.class, "expected class mismatched.");
+        Mockito.verify(nettyPipeline, Mockito.times(1)).addLast(Mockito.anyString(), handlerCaptorLast.capture());
+        Assert.assertEquals(handlerCaptorLast.getAllValues().size(), 1, "Unexpected count of ChannelHandler added.");
+        Assert.assertEquals(handlerCaptorLast.getAllValues().get(0).getClass(), SmtpClientConnectHandler.class, "expected class mismatched.");
         // verify if session level is on, whether debug call will be called
         // verify logging messages
         Mockito.verify(logger, Mockito.times(1)).debug(
@@ -499,10 +498,9 @@ public class SmtpAsyncClientTest {
         Assert.assertEquals(handlerCaptorAfter.getAllValues().get(0).getClass(), SslDetectHandler.class, "expected class mismatched.");
 
         final ArgumentCaptor<ChannelHandler> handlerCaptorLast = ArgumentCaptor.forClass(ChannelHandler.class);
-        Mockito.verify(nettyPipeline, Mockito.times(2)).addLast(Mockito.anyString(), handlerCaptorLast.capture());
-        Assert.assertEquals(handlerCaptorLast.getAllValues().size(), 2, "Unexpected count of ChannelHandler added.");
-        Assert.assertEquals(handlerCaptorLast.getAllValues().get(0).getClass(), ChunkedWriteHandler.class, "expected class mismatched.");
-        Assert.assertEquals(handlerCaptorLast.getAllValues().get(1).getClass(), SmtpClientConnectHandler.class, "expected class mismatched.");
+        Mockito.verify(nettyPipeline, Mockito.times(1)).addLast(Mockito.anyString(), handlerCaptorLast.capture());
+        Assert.assertEquals(handlerCaptorLast.getAllValues().size(), 1, "Unexpected count of ChannelHandler added.");
+        Assert.assertEquals(handlerCaptorLast.getAllValues().get(0).getClass(), SmtpClientConnectHandler.class, "expected class mismatched.");
         // verify if session level is on, whether debug call will be called
         // verify logging messages
         Mockito.verify(logger, Mockito.times(1)).debug(
@@ -590,10 +588,9 @@ public class SmtpAsyncClientTest {
         Assert.assertEquals(handlerCaptorAfter.getAllValues().get(0).getClass(), SslDetectHandler.class, "expected class mismatched.");
 
         final ArgumentCaptor<ChannelHandler> handlerCaptorLast = ArgumentCaptor.forClass(ChannelHandler.class);
-        Mockito.verify(nettyPipeline, Mockito.times(2)).addLast(Mockito.anyString(), handlerCaptorLast.capture());
-        Assert.assertEquals(handlerCaptorLast.getAllValues().size(), 2, "Unexpected count of ChannelHandler added.");
-        Assert.assertEquals(handlerCaptorLast.getAllValues().get(1).getClass(), SmtpClientConnectHandler.class, "expected class mismatched.");
-        Assert.assertEquals(handlerCaptorLast.getAllValues().get(0).getClass(), ChunkedWriteHandler.class, "expected class mismatched.");
+        Mockito.verify(nettyPipeline, Mockito.times(1)).addLast(Mockito.anyString(), handlerCaptorLast.capture());
+        Assert.assertEquals(handlerCaptorLast.getAllValues().size(), 1, "Unexpected count of ChannelHandler added.");
+        Assert.assertEquals(handlerCaptorLast.getAllValues().get(0).getClass(), SmtpClientConnectHandler.class, "expected class mismatched.");
 
         // verify to make sure logger isn't called
         Mockito.verify(logger, Mockito.times(0)).debug(Mockito.anyString(), Mockito.anyLong(), Mockito.anyString(), Mockito.anyString(),
@@ -1007,10 +1004,9 @@ public class SmtpAsyncClientTest {
         Assert.assertEquals(handlerCaptorAfter.getAllValues().get(0).getClass(), SslDetectHandler.class, "expected class mismatched.");
 
         final ArgumentCaptor<ChannelHandler> handlerCaptorLast = ArgumentCaptor.forClass(ChannelHandler.class);
-        Mockito.verify(nettyPipeline, Mockito.times(2)).addLast(Mockito.anyString(), handlerCaptorLast.capture());
-        Assert.assertEquals(handlerCaptorLast.getAllValues().size(), 2, "Unexpected count of ChannelHandler added.");
-        Assert.assertEquals(handlerCaptorLast.getAllValues().get(0).getClass(), ChunkedWriteHandler.class, "expected class mismatched.");
-        Assert.assertEquals(handlerCaptorLast.getAllValues().get(1).getClass(), SmtpClientConnectHandler.class, "expected class mismatched.");
+        Mockito.verify(nettyPipeline, Mockito.times(1)).addLast(Mockito.anyString(), handlerCaptorLast.capture());
+        Assert.assertEquals(handlerCaptorLast.getAllValues().size(), 1, "Unexpected count of ChannelHandler added.");
+        Assert.assertEquals(handlerCaptorLast.getAllValues().get(0).getClass(), SmtpClientConnectHandler.class, "expected class mismatched.");
         // verify if session level is on, whether debug call will be called
         // verify logging messages
         Mockito.verify(logger, Mockito.times(1)).debug(
@@ -1193,10 +1189,9 @@ public class SmtpAsyncClientTest {
         Assert.assertEquals(handlerCaptorAfter.getAllValues().get(0).getClass(), SslDetectHandler.class, "expected class mismatched.");
 
         final ArgumentCaptor<ChannelHandler> handlerCaptorLast = ArgumentCaptor.forClass(ChannelHandler.class);
-        Mockito.verify(nettyPipeline, Mockito.times(2)).addLast(Mockito.anyString(), handlerCaptorLast.capture());
-        Assert.assertEquals(handlerCaptorLast.getAllValues().size(), 2, "Unexpected count of ChannelHandler added.");
-        Assert.assertEquals(handlerCaptorLast.getAllValues().get(1).getClass(), SmtpClientConnectHandler.class, "expected class mismatched.");
-        Assert.assertEquals(handlerCaptorLast.getAllValues().get(0).getClass(), ChunkedWriteHandler.class, "expected class mismatched.");
+        Mockito.verify(nettyPipeline, Mockito.times(1)).addLast(Mockito.anyString(), handlerCaptorLast.capture());
+        Assert.assertEquals(handlerCaptorLast.getAllValues().size(), 1, "Unexpected count of ChannelHandler added.");
+        Assert.assertEquals(handlerCaptorLast.getAllValues().get(0).getClass(), SmtpClientConnectHandler.class, "expected class mismatched.");
 
         // verify logging messages
         Mockito.verify(logger, Mockito.times(1)).debug(
@@ -1290,10 +1285,9 @@ public class SmtpAsyncClientTest {
 
 
         final ArgumentCaptor<ChannelHandler> handlerCaptorLast = ArgumentCaptor.forClass(ChannelHandler.class);
-        Mockito.verify(nettyPipeline, Mockito.times(2)).addLast(Mockito.anyString(), handlerCaptorLast.capture());
-        Assert.assertEquals(handlerCaptorLast.getAllValues().size(), 2, "Unexpected count of ChannelHandler added.");
-        Assert.assertEquals(handlerCaptorLast.getAllValues().get(1).getClass(), SmtpClientConnectHandler.class, "expected class mismatched.");
-        Assert.assertEquals(handlerCaptorLast.getAllValues().get(0).getClass(), ChunkedWriteHandler.class, "expected class mismatched.");
+        Mockito.verify(nettyPipeline, Mockito.times(1)).addLast(Mockito.anyString(), handlerCaptorLast.capture());
+        Assert.assertEquals(handlerCaptorLast.getAllValues().size(), 1, "Unexpected count of ChannelHandler added.");
+        Assert.assertEquals(handlerCaptorLast.getAllValues().get(0).getClass(), SmtpClientConnectHandler.class, "expected class mismatched.");
 
         // verify logging messages
         Mockito.verify(logger, Mockito.times(1)).debug(Mockito.eq(

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.yahoo.smtpnio</groupId>
     <artifactId>smtpnio</artifactId>
     <packaging>pom</packaging>
-    <version>1.1.3</version>
+    <version>1.1.4</version>
     <name>${project.artifactId}</name>
     <url>https://github.com/yahoo/smtp-client-nio</url>
     <description>Parent POM file for smtpnio project</description>


### PR DESCRIPTION
Remove duplicate chunked-writer handler

## Description
Remove duplicate chunked-writer handler

## Motivation and Context
2023-06-27 22:53:23,665 [nioEventLoopGroup-10-1] WARN io.netty.util.concurrent.DefaultPromise - An exception was thrown by com.yahoo.smtpnio.async.client.SmtpAsyncClient$1.operationComplete()
java.lang.IllegalArgumentException: Duplicate handler name: chunked-writer
	at io.netty.channel.DefaultChannelPipeline.checkDuplicateName(DefaultChannelPipeline.java:1055)
	at io.netty.channel.DefaultChannelPipeline.filterName(DefaultChannelPipeline.java:284)
	at io.netty.channel.DefaultChannelPipeline.addLast(DefaultChannelPipeline.java:204)
	at io.netty.channel.DefaultChannelPipeline.addLast(DefaultChannelPipeline.java:195)
	at com.yahoo.smtpnio.async.client.SmtpAsyncClient$1.operationComplete(SmtpAsyncClient.java:230)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Major release (change is NOT backward compatible with prior release)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
